### PR TITLE
Refactor: Provider to Provider API string

### DIFF
--- a/trae_agent/cli.py
+++ b/trae_agent/cli.py
@@ -20,7 +20,9 @@ from dotenv import load_dotenv
 from trae_agent.utils.cli_console import CLIConsole
 
 from .agent import TraeAgent
-from .utils.config import Config, resolve_config_value
+from .utils.config import (
+    Config, resolve_config_value, provider_to_providerAPI
+)
 
 # Load environment variables
 _ = load_dotenv()
@@ -57,8 +59,7 @@ def load_config(provider: str | None = None, model: str | None = None, api_key: 
     resolved_api_key = resolve_config_value(
         api_key,
         config.model_providers[str(resolved_provider)].api_key,
-        # TODO: Shall we use a more robust method ? This would be much more convience to support more providers
-        "OPENAI_API_KEY" if resolved_provider == "openai" else "ANTHROPIC_API_KEY"
+        provider_to_providerAPI(resolved_provider)
     )
     if resolved_api_key is not None:
         # If None shall we stop the program ? 

--- a/trae_agent/utils/config.py
+++ b/trae_agent/utils/config.py
@@ -123,3 +123,17 @@ def resolve_config_value(cli_value: int | str | float | None, config_value: int 
         return config_value
 
     return None
+
+def provider_to_providerAPI(provider: str) -> str:
+    """
+        provider_to_providerAPI provides a clean way to convert provider to provider_API_Key string. 
+        Args:
+            provider: a string representing the provider
+        Return:
+            A string representing maping the API KEY in the config file for specific provider.
+    """
+    match provider:
+        case "openai":
+            return "OPENAI_API_KEY" 
+        case _:
+            return "ANTHROPIC_API_KEY"


### PR DESCRIPTION
The PR is a follow up PR after noticing the issues that require support of different models. 

where I think we need a more robust way to handle different providers.
This PR handles provider to provider API string function. Instead of just if else I refactor to another function in the config.py file. 

(Sorry my bad I forget to switch to main before opening another branch so a bit duplicated with previous pull request but the content isn't too much so I didn't switch back.) 