### PR TITLE
Feature: Gemini Models Support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "openai>=1.86.0",
     "anthropic>=0.54.0",
     "click>=8.0.0",
+    "google-genai>=1.24.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
     "rich>=13.0.0",

--- a/tests/utils/test_ollama_client_utils.py
+++ b/tests/utils/test_ollama_client_utils.py
@@ -5,23 +5,26 @@ Currently, we only test init, chat, and set chat history.
 
 WARNING: This Ollama test should not be used in the GitHub Actions workflow, as using Ollama for testing consumes too much time due to installation.
 """
+
+import os
+import sys
 import unittest
-import sys 
-import os 
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
 
-from trae_agent.utils.ollama_client import OllamaClient
 from trae_agent.utils.config import ModelParameters
 from trae_agent.utils.llm_basics import LLMMessage
+from trae_agent.utils.ollama_client import OllamaClient
 
 TEST_MODEL = "qwen3:4b"
+
 
 class TestOllamaClient(unittest.TestCase):
     def test_OllamaClient_init(self):
         """
-            Test ollama client provides a test case for initialize the ollama client
-            It should not be used to check any configiguration based on BaseLLMClient instead we should just check the parameters 
-            that will change during the init process.
+        Test ollama client provides a test case for initialize the ollama client
+        It should not be used to check any configiguration based on BaseLLMClient instead we should just check the parameters
+        that will change during the init process.
         """
         model_parameters = ModelParameters()
         model_parameters.model = "tester"
@@ -29,39 +32,36 @@ class TestOllamaClient(unittest.TestCase):
         model_parameters.max_tokens = 1234
         model_parameters.temperature = 0.8
         ollama_client = OllamaClient(model_parameters)
-        self.assertEqual(ollama_client.api_key , "ollama")
-        self.assertEqual(ollama_client.base_url , "http://localhost:11434")
+        self.assertEqual(ollama_client.api_key, "ollama")
+        self.assertEqual(ollama_client.base_url, "http://localhost:11434")
 
-    
     def test_ollama_set_chat_history(self):
         """
-            There is nothing we have to assert for this test case just see if it can run 
+        There is nothing we have to assert for this test case just see if it can run
         """
         model_parameters = ModelParameters()
         model_parameters.model = TEST_MODEL
         ollama_client = OllamaClient(model_parameters)
 
-        message = LLMMessage("user" , "this is a test message")
+        message = LLMMessage("user", "this is a test message")
         ollama_client.set_chat_history(messages=[message])
 
     def test_ollama_chat(self):
         """
-            There is nothing we have to assert for this test case just see if it can run 
+        There is nothing we have to assert for this test case just see if it can run
         """
         model_parameters = ModelParameters()
         model_parameters.model = TEST_MODEL
-        ollama_client = OllamaClient(model_parameters) 
-        message = LLMMessage("user" , "this is a test message")
-        ollama_client.chat(messages = [message] , model_parameters=model_parameters)
-
+        ollama_client = OllamaClient(model_parameters)
+        message = LLMMessage("user", "this is a test message")
+        ollama_client.chat(messages=[message], model_parameters=model_parameters)
 
     def test_supports_tool_calling(self):
         """
-            A test case to check the support tool calling function
+        A test case to check the support tool calling function
         """
         model_parameters = ModelParameters()
         model_parameters.model = TEST_MODEL
-        ollama_client = OllamaClient(model_parameters) 
-        self.assertEqual(ollama_client.supports_tool_calling("qwen2.5") , True)
-        self.assertEqual(ollama_client.supports_tool_calling("not support"),  False)
-
+        ollama_client = OllamaClient(model_parameters)
+        self.assertEqual(ollama_client.supports_tool_calling("qwen2.5"), True)
+        self.assertEqual(ollama_client.supports_tool_calling("not support"), False)

--- a/trae_agent/cli.py
+++ b/trae_agent/cli.py
@@ -76,7 +76,7 @@ def load_config(
     resolved_api_key = resolve_config_value(
         api_key,
         config.model_providers[str(resolved_provider)].api_key,
-        env_var_map.get(str(resolved_provider))
+        env_var_map.get(str(resolved_provider)),
     )
 
     if resolved_api_key is not None:

--- a/trae_agent/cli.py
+++ b/trae_agent/cli.py
@@ -70,12 +70,13 @@ def load_config(
         "azure": "AZURE_API_KEY",
         "openrouter": "OPENROUTER_API_KEY",
         "doubao": "DOUBAO_API_KEY",
+        "google": "GOOGLE_API_KEY",
     }
 
     resolved_api_key = resolve_config_value(
         api_key,
         config.model_providers[str(resolved_provider)].api_key,
-        env_var_map.get(str(resolved_provider)),
+        env_var_map.get(str(resolved_provider))
     )
 
     if resolved_api_key is not None:

--- a/trae_agent/tools/base.py
+++ b/trae_agent/tools/base.py
@@ -32,6 +32,7 @@ class ToolResult:
     """Result of a tool execution."""
 
     call_id: str
+    name: str #Gemini specific field
     success: bool
     result: str | None = None
     error: str | None = None
@@ -158,6 +159,7 @@ class ToolExecutor:
         """Execute a tool call."""
         if tool_call.name not in self.tools:
             return ToolResult(
+                name=tool_call.name, 
                 success=False,
                 error=f"Tool '{tool_call.name}' not found. Available tools: {list(self.tools.keys())}",
                 call_id=tool_call.call_id,
@@ -169,6 +171,7 @@ class ToolExecutor:
         try:
             tool_exec_result = await tool.execute(tool_call.arguments)
             return ToolResult(
+                name=tool_call.name,
                 success=tool_exec_result.error_code == 0,
                 result=tool_exec_result.output,
                 error=tool_exec_result.error,
@@ -177,6 +180,7 @@ class ToolExecutor:
             )
         except Exception as e:
             return ToolResult(
+                name=tool_call.name,
                 success=False,
                 error=f"Error executing tool '{tool_call.name}': {str(e)}",
                 call_id=tool_call.call_id,

--- a/trae_agent/tools/base.py
+++ b/trae_agent/tools/base.py
@@ -32,7 +32,7 @@ class ToolResult:
     """Result of a tool execution."""
 
     call_id: str
-    name: str #Gemini specific field
+    name: str  # Gemini specific field
     success: bool
     result: str | None = None
     error: str | None = None
@@ -159,7 +159,7 @@ class ToolExecutor:
         """Execute a tool call."""
         if tool_call.name not in self.tools:
             return ToolResult(
-                name=tool_call.name, 
+                name=tool_call.name,
                 success=False,
                 error=f"Tool '{tool_call.name}' not found. Available tools: {list(self.tools.keys())}",
                 call_id=tool_call.call_id,

--- a/trae_agent/utils/config.py
+++ b/trae_agent/utils/config.py
@@ -30,6 +30,8 @@ class ModelParameters:
     max_retries: int
     base_url: str | None = None
     api_version: str | None = None
+    candidate_count: int | None = None #Gemini specific field
+    stop_sequences: list[str] | None = None 
 
 
 @dataclass
@@ -99,15 +101,11 @@ class Config:
                     top_p=float(provider_config.get("top_p", 1)),
                     top_k=int(provider_config.get("top_k", 0)),
                     max_retries=int(provider_config.get("max_retries", 10)),
-                    parallel_tool_calls=bool(
-                        provider_config.get("parallel_tool_calls", False)
-                    ),
-                    base_url=str(provider_config.get("base_url"))
-                    if "base_url" in provider_config
-                    else None,
-                    api_version=str(provider_config.get("api_version"))
-                    if "api_version" in provider_config
-                    else None,
+                    parallel_tool_calls=bool(provider_config.get("parallel_tool_calls", False)),
+                    base_url=str(provider_config.get("base_url")) if "base_url" in provider_config else None,
+                    api_version=str(provider_config.get("api_version")) if "api_version" in provider_config else None,
+                    candidate_count=int(provider_config.get("candidate_count")) if "candidate_count" in provider_config else None,
+                    stop_sequences=provider_config.get("stop_sequences") if "stop_sequences" in provider_config else None,
                 )
 
         if "lakeview_config" in self._config:

--- a/trae_agent/utils/config.py
+++ b/trae_agent/utils/config.py
@@ -12,7 +12,7 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import override
+from typing import Any, override
 
 
 # data class for model parameters
@@ -30,8 +30,8 @@ class ModelParameters:
     max_retries: int
     base_url: str | None = None
     api_version: str | None = None
-    candidate_count: int | None = None #Gemini specific field
-    stop_sequences: list[str] | None = None 
+    candidate_count: int | None = None  # Gemini specific field
+    stop_sequences: list[str] | None = None
 
 
 @dataclass
@@ -90,9 +90,11 @@ class Config:
             }
         else:
             for provider in self._config.get("model_providers", {}):
-                provider_config: dict[str, str | int | float | bool] = self._config.get(
+                provider_config: dict[str, Any] = self._config.get(
                     "model_providers", {}
                 ).get(provider, {})
+
+                candidate_count = provider_config.get("candidate_count")
                 self.model_providers[provider] = ModelParameters(
                     model=str(provider_config.get("model", "")),
                     api_key=str(provider_config.get("api_key", "")),
@@ -101,11 +103,21 @@ class Config:
                     top_p=float(provider_config.get("top_p", 1)),
                     top_k=int(provider_config.get("top_k", 0)),
                     max_retries=int(provider_config.get("max_retries", 10)),
-                    parallel_tool_calls=bool(provider_config.get("parallel_tool_calls", False)),
-                    base_url=str(provider_config.get("base_url")) if "base_url" in provider_config else None,
-                    api_version=str(provider_config.get("api_version")) if "api_version" in provider_config else None,
-                    candidate_count=int(provider_config.get("candidate_count")) if "candidate_count" in provider_config else None,
-                    stop_sequences=provider_config.get("stop_sequences") if "stop_sequences" in provider_config else None,
+                    parallel_tool_calls=bool(
+                        provider_config.get("parallel_tool_calls", False)
+                    ),
+                    base_url=str(provider_config.get("base_url"))
+                    if "base_url" in provider_config
+                    else None,
+                    api_version=str(provider_config.get("api_version"))
+                    if "api_version" in provider_config
+                    else None,
+                    candidate_count=int(candidate_count)
+                    if candidate_count is not None
+                    else None,
+                    stop_sequences=provider_config.get("stop_sequences")
+                    if "stop_sequences" in provider_config
+                    else None,
                 )
 
         if "lakeview_config" in self._config:

--- a/trae_agent/utils/google_client.py
+++ b/trae_agent/utils/google_client.py
@@ -159,7 +159,7 @@ class GoogleClient(BaseLLMClient):
     def supports_tool_calling(self, model_parameters: ModelParameters) -> bool:
         """Check if the current model supports tool calling."""
         tool_capable_models = [
-            "gemini-2.5-pro", "gemini-2.5-flash", "gemini-1.5-pro", "gemini-1.5-flash", "gemini-1.0-pro"
+            "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.0-flash"
         ]
         return any(model_name in model_parameters.model for model_name in tool_capable_models)
 

--- a/trae_agent/utils/google_client.py
+++ b/trae_agent/utils/google_client.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Google Gemini API client wrapper with tool integration."""
+
+import os
+import json
+import random
+import time
+import traceback
+from typing import override, Any, Dict, List, Union
+
+from google import genai
+from google.genai import types
+
+from ..tools.base import Tool, ToolCall, ToolResult
+from .config import ModelParameters
+from .base_client import BaseLLMClient
+from .llm_basics import LLMMessage, LLMResponse, LLMUsage
+
+
+class GoogleClient(BaseLLMClient):
+    """Google Gemini client wrapper with tool schema generation."""
+
+    def __init__(self, model_parameters: ModelParameters):
+        super().__init__(model_parameters)
+
+        if self.api_key == "":
+            self.api_key: str = os.getenv("GOOGLE_API_KEY")
+
+        if self.api_key == "":
+            raise ValueError("Google API key not provided. Set GOOGLE_API_KEY in environment variables or config file.")
+
+        self.client = genai.Client(api_key=self.api_key)
+        self.message_history: list[types.Content] = []
+        self.system_instruction: str | None = None
+
+    @override
+    def set_chat_history(self, messages: list[LLMMessage]) -> None:
+        """Set the chat history."""
+        self.message_history, self.system_instruction = self.parse_messages(messages)
+
+    @override
+    def chat(self, messages: list[LLMMessage], model_parameters: ModelParameters, tools: list[Tool] | None = None, reuse_history: bool = True) -> LLMResponse:
+        """Send chat messages to Gemini with optional tool support."""
+        newly_parsed_messages, system_instruction_from_message = self.parse_messages(messages)
+        
+        current_system_instruction = system_instruction_from_message or self.system_instruction
+
+        if reuse_history:
+            current_chat_contents = self.message_history + newly_parsed_messages
+        else:
+            current_chat_contents = newly_parsed_messages
+
+        generation_config = types.GenerateContentConfig(
+            temperature=model_parameters.temperature,
+            top_p=model_parameters.top_p,
+            top_k=model_parameters.top_k,
+            max_output_tokens=model_parameters.max_tokens,
+            candidate_count=model_parameters.candidate_count or 1,
+            stop_sequences=model_parameters.stop_sequences,
+            system_instruction=current_system_instruction
+        )
+
+        if tools:
+            try:
+                declarations = [
+                    types.FunctionDeclaration(
+                        name=tool.name,
+                        description=tool.description,
+                        parameters=tool.get_input_schema(),
+                    )
+                    for tool in tools
+                ]
+                generation_config.tools = [types.Tool(function_declarations=declarations)]
+            except Exception as e:
+                tb = traceback.format_exc()
+                raise ValueError(f"Failed to convert tools into Gemini FunctionDeclarations: {e}\n{tb}") from e
+
+        response = None
+        error_message = ""
+        for i in range(model_parameters.max_retries):
+            try:
+                response = self.client.models.generate_content(
+                    model=model_parameters.model,
+                    contents=current_chat_contents,
+                    config=generation_config,
+                )
+                break
+            except Exception as e:
+                tb = traceback.format_exc()
+                error_message += f"Error {i + 1}: {str(e)}\nTraceback:\n{tb}\n"
+                time.sleep(random.randint(3, 30))
+                continue
+
+        if response is None:
+            raise ValueError(f"Failed to get response from Gemini after max retries: {error_message}")
+
+        content = ""
+        tool_calls: list[ToolCall] = []
+        assistant_response_content = None
+
+        if response.candidates:
+            candidate = response.candidates[0]
+            if candidate.content and candidate.content.parts:
+                assistant_response_content = candidate.content
+                for part in candidate.content.parts:
+                    if part.text:
+                        content += part.text
+                    elif part.function_call:
+                        tool_calls.append(ToolCall(
+                            call_id=str(random.randint(1000, 9999)),
+                            name=part.function_call.name,
+                            arguments=dict(part.function_call.args) if part.function_call.args else {}
+                        ))
+
+        if reuse_history:
+            new_history = self.message_history + newly_parsed_messages
+        else:
+            new_history = newly_parsed_messages
+
+        if assistant_response_content:
+            new_history.append(assistant_response_content)
+
+        self.message_history = new_history
+
+        if current_system_instruction:
+            self.system_instruction = current_system_instruction
+            
+        usage = None
+        if response.usage_metadata:
+            usage = LLMUsage(
+                input_tokens=response.usage_metadata.prompt_token_count,
+                output_tokens=response.usage_metadata.candidates_token_count,
+                cache_read_input_tokens=response.usage_metadata.cached_content_token_count or 0,
+                cache_creation_input_tokens=0
+            )
+
+        llm_response = LLMResponse(
+            content=content,
+            usage=usage,
+            model=model_parameters.model,
+            finish_reason=str(response.candidates[0].finish_reason.name) if response.candidates else "UNKNOWN",
+            tool_calls=tool_calls if len(tool_calls) > 0 else None
+        )
+
+        if self.trajectory_recorder:
+            self.trajectory_recorder.record_llm_interaction(
+                messages=messages,
+                response=llm_response,
+                provider="google",
+                model=model_parameters.model,
+                tools=tools
+            )
+
+        return llm_response
+
+    @override
+    def supports_tool_calling(self, model_parameters: ModelParameters) -> bool:
+        """Check if the current model supports tool calling."""
+        tool_capable_models = [
+            "gemini-2.5-pro", "gemini-2.5-flash", "gemini-1.5-pro", "gemini-1.5-flash", "gemini-1.0-pro"
+        ]
+        return any(model_name in model_parameters.model for model_name in tool_capable_models)
+
+    def parse_messages(self, messages: list[LLMMessage]) -> tuple[list[types.Content], str | None]:
+        """Parse the messages to Gemini format, separating system instructions."""
+        gemini_messages: list[types.Content] = []
+        system_instruction: str | None = None
+        
+        for msg in messages:
+            if msg.role == "system":
+                system_instruction = msg.content
+                continue
+            elif msg.tool_result:
+                gemini_messages.append(types.Content(
+                    role="tool",
+                    parts=[self.parse_tool_call_result(msg.tool_result)]
+                ))
+            elif msg.tool_call:
+                gemini_messages.append(types.Content(
+                    role="model",
+                    parts=[self.parse_tool_call(msg.tool_call)]
+                ))
+            else:
+                role = "user" if msg.role == "user" else "model"
+                gemini_messages.append(types.Content(
+                    role=role,
+                    parts=[types.Part(text=msg.content or "")] 
+                ))
+        
+        return gemini_messages, system_instruction
+
+    def parse_tool_call(self, tool_call: ToolCall) -> types.Part:
+        """Parse a ToolCall into a Gemini FunctionCall Part for history."""
+        return types.Part.from_function_call(
+            name=tool_call.name,
+            args=tool_call.arguments
+        )
+
+    def parse_tool_call_result(self, tool_result: ToolResult) -> types.Part:
+        """Parse a ToolResult into a Gemini FunctionResponse Part for history."""
+        result_content = {}
+        if tool_result.result is not None:
+            if isinstance(tool_result.result, (str, int, float, bool, list, dict)):
+                try:
+                    json.dumps(tool_result.result)
+                    result_content["result"] = tool_result.result
+                except (TypeError, OverflowError) as e:
+                    tb = traceback.format_exc()
+                    serialization_error = f"JSON serialization failed for tool result: {e}\n{tb}"
+                    if tool_result.error:
+                        result_content["error"] = f"{tool_result.error}\n\n{serialization_error}"
+                    else:
+                        result_content["error"] = serialization_error
+                    result_content["result"] = str(tool_result.result)
+            else:
+                result_content["result"] = str(tool_result.result)
+        
+        if tool_result.error and "error" not in result_content:
+            result_content["error"] = tool_result.error
+        
+        if not result_content:
+            result_content["status"] = "Tool executed successfully but returned no output."
+
+        if not hasattr(tool_result, 'name') or not tool_result.name:
+            raise AttributeError("ToolResult must have a 'name' attribute matching the function that was called.")
+
+        return types.Part.from_function_response(
+            name=tool_result.name,
+            response=result_content
+        )

--- a/trae_agent/utils/google_client.py
+++ b/trae_agent/utils/google_client.py
@@ -131,8 +131,8 @@ class GoogleClient(BaseLLMClient):
         usage = None
         if response.usage_metadata:
             usage = LLMUsage(
-                input_tokens=response.usage_metadata.prompt_token_count,
-                output_tokens=response.usage_metadata.candidates_token_count,
+                input_tokens=response.usage_metadata.prompt_token_count or 0,
+                output_tokens=response.usage_metadata.candidates_token_count or 0,
                 cache_read_input_tokens=response.usage_metadata.cached_content_token_count or 0,
                 cache_creation_input_tokens=0
             )

--- a/trae_agent/utils/google_client.py
+++ b/trae_agent/utils/google_client.py
@@ -8,6 +8,7 @@ import json
 import random
 import time
 import traceback
+import uuid
 from typing import override, Any, Dict, List, Union
 
 from google import genai
@@ -109,7 +110,7 @@ class GoogleClient(BaseLLMClient):
                         content += part.text
                     elif part.function_call:
                         tool_calls.append(ToolCall(
-                            call_id=str(random.randint(1000, 9999)),
+                            call_id=str(uuid.uuid4()),
                             name=part.function_call.name,
                             arguments=dict(part.function_call.args) if part.function_call.args else {}
                         ))

--- a/trae_agent/utils/llm_client.py
+++ b/trae_agent/utils/llm_client.py
@@ -21,6 +21,7 @@ class LLMProvider(Enum):
     OLLAMA = "ollama"
     OPENROUTER = "openrouter"
     DOUBAO = "doubao"
+    GOOGLE = "google"
 
 
 class LLMClient:
@@ -57,6 +58,10 @@ class LLMClient:
                 from .ollama_client import OllamaClient
 
                 self.client = OllamaClient(model_parameters)
+            case LLMProvider.GOOGLE:
+                from .google_client import GoogleClient
+
+                self.client = GoogleClient(model_parameters)
 
     def set_trajectory_recorder(self, recorder: TrajectoryRecorder | None) -> None:
         """Set the trajectory recorder for the underlying client."""

--- a/trae_agent/utils/ollama_client.py
+++ b/trae_agent/utils/ollama_client.py
@@ -35,7 +35,9 @@ class OllamaClient(BaseLLMClient):
         self.client: openai.OpenAI = openai.OpenAI(
             # by default ollama doesn't require any api key. It should set to be "ollama".
             api_key=self.api_key,
-            base_url=model_parameters.base_url if model_parameters.base_url else "http://localhost:11434"
+            base_url=model_parameters.base_url
+            if model_parameters.base_url
+            else "http://localhost:11434",
         )
 
         self.message_history: ResponseInputParam = []
@@ -164,8 +166,8 @@ class OllamaClient(BaseLLMClient):
     @override
     def supports_tool_calling(self, model_parameters: ModelParameters) -> bool:
         """
-            Check if the current model supports tool calling.
-            TODO: there should be a more robust way to handle tool_support check or we have to manually type every supported model which is not really that feasible. for example deepseek familay has deepseek:1.5b deepseek:7b ...
+        Check if the current model supports tool calling.
+        TODO: there should be a more robust way to handle tool_support check or we have to manually type every supported model which is not really that feasible. for example deepseek familay has deepseek:1.5b deepseek:7b ...
         """
         tool_support_model = [
             "deepseek-r1",

--- a/trae_config.json
+++ b/trae_config.json
@@ -20,6 +20,15 @@
       "top_k": 0,
       "max_retries": 10
     },
+    "google": {
+      "api_key": "your_google_api_key",
+      "model": "gemini-2.5-flash",
+      "max_tokens": 120000,
+      "temperature": 0.5,
+      "top_p": 1,
+      "top_k": 0,
+      "max_retries": 10
+    },
     "azure": {
       "api_key": "you_azure_api_key",
       "base_url": "your_azure_base_url",

--- a/uv.lock
+++ b/uv.lock
@@ -126,6 +126,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "5.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
@@ -387,6 +396,39 @@ wheels = [
 [package.optional-dependencies]
 http = [
     { name = "aiohttp" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.40.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/9b/e92ef23b84fa10a64ce4831390b7a4c2e53c0132568d99d4ae61d04c8855/google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77", size = 281029, upload-time = "2025-06-04T18:04:57.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/63/b19553b658a1692443c62bd07e5868adaa0ad746a0751ba62c59568cd45b/google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca", size = 216137, upload-time = "2025-06-04T18:04:55.573Z" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "google-auth" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/cf/37ac8cd4752e28e547b8a52765fe48a2ada2d0d286ea03f46e4d8c69ff4f/google_genai-1.24.0.tar.gz", hash = "sha256:bc896e30ad26d05a2af3d17c2ba10ea214a94f1c0cdb93d5c004dc038774e75a", size = 226740, upload-time = "2025-07-01T22:14:24.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/28/a35f64fc02e599808101617a21d447d241dadeba2aac1f4dc2d1179b8218/google_genai-1.24.0-py3-none-any.whl", hash = "sha256:98be8c51632576289ecc33cd84bcdaf4356ef0bef04ac7578660c49175af22b9", size = 226065, upload-time = "2025-07-01T22:14:23.177Z" },
 ]
 
 [[package]]
@@ -874,6 +916,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1090,6 +1153,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1105,6 +1180,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/4d/6a19536c50b849338fcbe9290d562b52cbdcf30d8963d3588a68a4107df1/tenacity-8.5.0.tar.gz", hash = "sha256:8bc6c0c8a09b31e6cad13c47afbed1a567518250a9a171418582ed8d9c20ca78", size = 47309, upload-time = "2024-07-05T07:25:31.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/3f/8ba87d9e287b9d385a02a7114ddcef61b26f86411e121c9003eb509a1773/tenacity-8.5.0-py3-none-any.whl", hash = "sha256:b594c2a5945830c267ce6b79a166228323ed52718f30302c1359836112346687", size = 28165, upload-time = "2024-07-05T07:25:29.591Z" },
 ]
 
 [[package]]
@@ -1126,6 +1210,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "click" },
+    { name = "google-genai" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -1152,6 +1237,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0.0" },
     { name = "datasets", marker = "extra == 'evaluation'", specifier = ">=3.6.0" },
     { name = "docker", marker = "extra == 'evaluation'", specifier = ">=7.1.0" },
+    { name = "google-genai", specifier = ">=1.24.0" },
     { name = "openai", specifier = ">=1.86.0" },
     { name = "pre-commit", marker = "extra == 'test'", specifier = ">=4.2.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -1216,6 +1302,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/56/2c/444f465fb2c65f40c3a104fd0c495184c4f2336d65baf398e3c75d72ea94/virtualenv-20.31.2.tar.gz", hash = "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af", size = 6076316, upload-time = "2025-05-08T17:58:23.811Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/40/b1c265d4b2b62b58576588510fc4d1fe60a86319c8de99fd8e9fec617d2c/virtualenv-20.31.2-py3-none-any.whl", hash = "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11", size = 6057982, upload-time = "2025-05-08T17:58:21.15Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR introduces a new `GoogleClient` for interacting with the Google Gemini API, providing full support for chat, tool calling, and other native features. #15 

1.  Added Gemini-specific field `name` for function-calling/tool-calling support.
2.  Added Gemini-specific `candidate_count` parameter.
3.  Added `stop_sequences` parameter that allows users to use tags like `<summary>`, `<thinking>`, etc., in their prompt. Stop_sequences works with gemini models however other models haven't been tested yet.
4.  Integrated `googleClient` with the latest `google-genai` 1.24.0 SDK.
5.  Implemented `call_id` generation for Gemini tool calls to align with Trae's unified `ToolCall` interface, as this is not provided by the native API.
6.  Added a sample config for Google in `trae_config.json`.