### PR TITLE
Documentation: Add Ollama example in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ trae-cli run "Review this code" --provider openrouter --model "anthropic/claude-
 
 # Use Gemini through OpenRouter
 trae-cli run "Generate docs" --provider openrouter --model "google/gemini-pro"
+
+# Use Qwen through Ollama
+trae-cli run "Comment this code" --provider ollama --model "qwen3"
 ```
 
 **Popular OpenRouter Models:**


### PR DESCRIPTION
## Description
This PR updates the README.md in the documentation with an example of how to use Ollama to run the Trae agent.

## More Information

Update documentation with an example.  

## Validation
N/A

## Linked Issues

N/A


