### PR TITLE
Fix suggested absolute path to start with '/'

### DIFF
--- a/trae_agent/tools/edit_tool.py
+++ b/trae_agent/tools/edit_tool.py
@@ -176,7 +176,7 @@ Notes for using the `str_replace` command:
     def validate_path(self, command: str, path: Path):
         """Validate the path for the str_replace_editor tool."""
         if not path.is_absolute():
-            suggested_path = Path("") / path
+            suggested_path = Path("/") / path
             raise ToolError(
                 f"The path {path} is not an absolute path, it should start with `/`. Maybe you meant {suggested_path}?"
             )


### PR DESCRIPTION
## Description

The `suggested_path` was constructed using `Path("")` which creates a same path as `path`. Should use `Path("/")` to construct an absolute path as suggestion.

## More Information

/

## Validation

/

## Linked Issues

/
