### PR TITLE
ci: Restrict CI execution to the origin repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   pre-commit:
+
+    if: github.repository == 'bytedance/trae-agent'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Currently, the CI workflow is triggered by events (such as `push`) within forked repositories. This leads to unnecessary CI runs, consumes resources.

This PR ensures that the CI pipeline only runs in the context of the origin repository. It will no longer be triggered by activities within forks, but will still run correctly for events like pull requests submitted to this repository.
