### PR TITLE
docs: replace <repository-url> with real repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 We strongly recommend using [UV](https://docs.astral.sh/uv/) to setup the project.
 
 ```bash
-git clone <repository-url>
+git clone https://github.com/bytedance/trae-agent
 cd trae-agent
 uv sync
 ```


### PR DESCRIPTION
Maybe we should replace \<repository-url\> with the real repo url.
