### PR TITLE
fix(input-schema): additionaProperties is added to the input schema o…

### DIFF
--- a/trae_agent/tools/base.py
+++ b/trae_agent/tools/base.py
@@ -150,8 +150,11 @@ class Tool(ABC):
         if len(required) > 0:
             schema["required"] = required
 
-        # extra properties are not allowed
-        schema["additionalProperties"] = False
+        # For OpenAI, we need to specify that additional properties are not allowed.
+        # For Gemini, this field is not allowed.
+        if self.model_provider == "openai":
+            # extra properties are not allowed
+            schema["additionalProperties"] = False
 
         return schema
 


### PR DESCRIPTION
This PR fixes #67. The ```schema["additionalProperties"] = False``` is only necessary in the tool input payload if the model provider is OpenAI. Its a simple fix.