### PR TITLE
Add JSONEditTool for file editing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "anthropic>=0.54.0",
     "click>=8.0.0",
     "google-genai>=1.24.0",
+    "jsonpath-ng>=1.7.0",
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
     "rich>=13.0.0",

--- a/tests/tools/test_json_edit_tool.py
+++ b/tests/tools/test_json_edit_tool.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Tests for JSONEditTool."""
+
+import json
+import unittest
+from unittest.mock import mock_open, patch
+
+from trae_agent.tools.base import ToolCallArguments
+from trae_agent.tools.json_edit_tool import JSONEditTool
+
+
+class TestJSONEditTool(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        """Set up the test environment."""
+        self.tool = JSONEditTool()
+        self.test_file_path = "/test_dir/test_file.json"
+
+        # Default sample data
+        self.sample_data = {
+            "users": [{"id": 1, "name": "Alice"}, {"id": 2, "name": "Bob"}],
+            "config": {"enabled": True},
+        }
+
+    def mock_file_read(self, json_data=None):
+        """Helper to mock file reading operations."""
+        if json_data is None:
+            json_data = self.sample_data
+
+        read_content = json.dumps(json_data)
+        m_open = mock_open(read_data=read_content)
+
+        # Patch open and path checks
+        self.open_patcher = patch("builtins.open", m_open)
+        self.exists_patcher = patch("pathlib.Path.exists", return_value=True)
+        self.is_absolute_patcher = patch("pathlib.Path.is_absolute", return_value=True)
+
+        self.open_patcher.start()
+        self.exists_patcher.start()
+        self.is_absolute_patcher.start()
+
+        self.addCleanup(self.open_patcher.stop)
+        self.addCleanup(self.exists_patcher.stop)
+        self.addCleanup(self.is_absolute_patcher.stop)
+
+    @patch("json.dump")
+    async def test_set_config_value(self, mock_json_dump):
+        """Test setting a simple configuration value."""
+        self.mock_file_read()
+        result = await self.tool.execute(
+            ToolCallArguments(
+                {
+                    "operation": "set",
+                    "file_path": self.test_file_path,
+                    "json_path": "$.config.enabled",
+                    "value": False,
+                }
+            )
+        )
+        self.assertEqual(result.error_code, 0)
+
+        # Verify that json.dump was called with the correct data
+        mock_json_dump.assert_called_once()
+        written_data = mock_json_dump.call_args[0][0]
+        self.assertFalse(written_data["config"]["enabled"])
+
+    @patch("json.dump")
+    async def test_update_user_name(self, mock_json_dump):
+        """Test updating a name in a list of objects."""
+        self.mock_file_read()
+        result = await self.tool.execute(
+            ToolCallArguments(
+                {
+                    "operation": "set",
+                    "file_path": self.test_file_path,
+                    "json_path": "$.users[0].name",
+                    "value": "Alicia",
+                }
+            )
+        )
+        self.assertEqual(result.error_code, 0)
+
+        mock_json_dump.assert_called_once()
+        written_data = mock_json_dump.call_args[0][0]
+        self.assertEqual(written_data["users"][0]["name"], "Alicia")
+
+    @patch("json.dump")
+    async def test_add_new_user(self, mock_json_dump):
+        """Test adding a new object to a list (by inserting at the end)."""
+        self.mock_file_read()
+        result = await self.tool.execute(
+            ToolCallArguments(
+                {
+                    "operation": "add",
+                    "file_path": self.test_file_path,
+                    "json_path": "$.users[2]",  # Inserting at index 2 (end of list)
+                    "value": {"id": 3, "name": "Charlie"},
+                }
+            )
+        )
+        self.assertEqual(result.error_code, 0)
+
+        mock_json_dump.assert_called_once()
+        written_data = mock_json_dump.call_args[0][0]
+        self.assertEqual(len(written_data["users"]), 3)
+        self.assertEqual(written_data["users"][2]["name"], "Charlie")
+
+    @patch("json.dump")
+    async def test_add_new_config_key(self, mock_json_dump):
+        """Test adding a new key-value pair to an object."""
+        self.mock_file_read()
+        result = await self.tool.execute(
+            ToolCallArguments(
+                {
+                    "operation": "add",
+                    "file_path": self.test_file_path,
+                    "json_path": "$.config.version",
+                    "value": "1.1.0",
+                }
+            )
+        )
+        self.assertEqual(result.error_code, 0)
+
+        mock_json_dump.assert_called_once()
+        written_data = mock_json_dump.call_args[0][0]
+        self.assertEqual(written_data["config"]["version"], "1.1.0")
+
+    @patch("json.dump")
+    async def test_remove_user_by_index(self, mock_json_dump):
+        """Test removing an element from a list by its index."""
+        self.mock_file_read()
+        result = await self.tool.execute(
+            ToolCallArguments(
+                {
+                    "operation": "remove",
+                    "file_path": self.test_file_path,
+                    "json_path": "$.users[0]",
+                }
+            )
+        )
+        self.assertEqual(result.error_code, 0)
+
+        mock_json_dump.assert_called_once()
+        written_data = mock_json_dump.call_args[0][0]
+        self.assertEqual(len(written_data["users"]), 1)
+        self.assertEqual(written_data["users"][0]["name"], "Bob")
+
+    @patch("json.dump")
+    async def test_remove_config_key(self, mock_json_dump):
+        """Test removing a key from an object."""
+        self.mock_file_read()
+        result = await self.tool.execute(
+            ToolCallArguments(
+                {
+                    "operation": "remove",
+                    "file_path": self.test_file_path,
+                    "json_path": "$.config.enabled",
+                }
+            )
+        )
+        self.assertEqual(result.error_code, 0)
+
+        mock_json_dump.assert_called_once()
+        written_data = mock_json_dump.call_args[0][0]
+        self.assertNotIn("enabled", written_data["config"])
+
+    async def test_view_operation(self):
+        """Test the view operation to ensure it reads and returns content."""
+        self.mock_file_read()
+        result = await self.tool.execute(
+            ToolCallArguments(
+                {
+                    "operation": "view",
+                    "file_path": self.test_file_path,
+                    "json_path": "$.users[0]",
+                }
+            )
+        )
+        self.assertEqual(result.error_code, 0)
+        self.assertIn('"id": 1', result.output)
+        self.assertIn('"name": "Alice"', result.output)
+
+    async def test_error_file_not_found(self):
+        """Test error handling when the file does not exist."""
+        # Mock Path.exists to return False
+        with (
+            patch("pathlib.Path.exists", return_value=False),
+            patch("pathlib.Path.is_absolute", return_value=True),
+        ):
+            result = await self.tool.execute(
+                ToolCallArguments(
+                    {
+                        "operation": "view",
+                        "file_path": "/nonexistent/file.json",
+                    }
+                )
+            )
+            self.assertEqual(result.error_code, -1)
+            self.assertIn("File does not exist", result.error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trae_agent/agent/trae_agent.py
+++ b/trae_agent/agent/trae_agent.py
@@ -18,6 +18,7 @@ from .base import Agent
 TraeAgentToolNames = [
     "str_replace_based_edit_tool",
     "sequentialthinking",
+    "json_edit_tool",
     "task_done",
     "bash",
 ]

--- a/trae_agent/tools/__init__.py
+++ b/trae_agent/tools/__init__.py
@@ -8,6 +8,7 @@ from typing import Type
 from .base import Tool, ToolCall, ToolExecutor, ToolResult
 from .bash_tool import BashTool
 from .edit_tool import TextEditorTool
+from .json_edit_tool import JSONEditTool
 from .sequential_thinking_tool import SequentialThinkingTool
 from .task_done_tool import TaskDoneTool
 
@@ -18,6 +19,7 @@ __all__ = [
     "ToolExecutor",
     "BashTool",
     "TextEditorTool",
+    "JSONEditTool",
     "SequentialThinkingTool",
     "TaskDoneTool",
 ]
@@ -25,6 +27,7 @@ __all__ = [
 tools_registry: dict[str, Type[Tool]] = {
     "bash": BashTool,
     "str_replace_based_edit_tool": TextEditorTool,
+    "json_edit_tool": JSONEditTool,
     "sequentialthinking": SequentialThinkingTool,
     "task_done": TaskDoneTool,
 }

--- a/trae_agent/tools/json_edit_tool.py
+++ b/trae_agent/tools/json_edit_tool.py
@@ -77,7 +77,7 @@ JSONPath syntax supported:
             ),
             ToolParameter(
                 name="value",
-                type=["string", "number", "boolean", "object", "array", "null"],
+                type="object",
                 description="The value to set or add. Must be JSON-serializable. Required for set and add operations.",
                 required=False,
             ),

--- a/trae_agent/tools/json_edit_tool.py
+++ b/trae_agent/tools/json_edit_tool.py
@@ -1,0 +1,351 @@
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: MIT
+
+"""JSON editing tool for structured JSON file modifications."""
+
+import json
+from pathlib import Path
+from typing import override
+
+from jsonpath_ng import Fields, Index
+from jsonpath_ng import parse as jsonpath_parse
+from jsonpath_ng.exceptions import JSONPathError
+
+from .base import Tool, ToolCallArguments, ToolError, ToolExecResult, ToolParameter
+
+
+class JSONEditTool(Tool):
+    """Tool for editing JSON files using JSONPath expressions."""
+
+    def __init__(self, model_provider: str | None = None) -> None:
+        super().__init__(model_provider)
+
+    @override
+    def get_model_provider(self) -> str | None:
+        return self._model_provider
+
+    @override
+    def get_name(self) -> str:
+        return "json_edit_tool"
+
+    @override
+    def get_description(self) -> str:
+        return """Tool for editing JSON files with JSONPath expressions
+* Supports targeted modifications to JSON structures using JSONPath syntax
+* Operations: view, set, add, remove
+* JSONPath examples: '$.users[0].name', '$.config.database.host', '$.items[*].price'
+* Safe JSON parsing and validation with detailed error messages
+* Preserves JSON formatting where possible
+
+Operation details:
+- `view`: Display JSON content or specific paths
+- `set`: Update existing values at specified paths
+- `add`: Add new key-value pairs (for objects) or append to arrays
+- `remove`: Delete elements at specified paths
+
+JSONPath syntax supported:
+- `$` - root element
+- `.key` - object property access
+- `[index]` - array index access
+- `[*]` - all elements in array/object
+- `..key` - recursive descent (find key at any level)
+- `[start:end]` - array slicing
+"""
+
+    @override
+    def get_parameters(self) -> list[ToolParameter]:
+        """Get the parameters for the JSON edit tool."""
+        return [
+            ToolParameter(
+                name="operation",
+                type="string",
+                description="The operation to perform on the JSON file.",
+                required=True,
+                enum=["view", "set", "add", "remove"],
+            ),
+            ToolParameter(
+                name="file_path",
+                type="string",
+                description="Absolute path to the JSON file to edit.",
+                required=True,
+            ),
+            ToolParameter(
+                name="json_path",
+                type="string",
+                description="JSONPath expression to specify the target location (e.g., '$.users[0].name', '$.config.database'). Required for set, add, and remove operations. Optional for view to show specific paths.",
+                required=False,
+            ),
+            ToolParameter(
+                name="value",
+                type=["string", "number", "boolean", "object", "array", "null"],
+                description="The value to set or add. Must be JSON-serializable. Required for set and add operations.",
+                required=False,
+            ),
+            ToolParameter(
+                name="pretty_print",
+                type="boolean",
+                description="Whether to format the JSON output with proper indentation. Defaults to true.",
+                required=False,
+            ),
+        ]
+
+    @override
+    async def execute(self, arguments: ToolCallArguments) -> ToolExecResult:
+        """Execute the JSON edit operation."""
+        try:
+            operation = str(arguments.get("operation", "")).lower()
+            if not operation:
+                return ToolExecResult(
+                    error="Operation parameter is required", error_code=-1
+                )
+
+            file_path_str = str(arguments.get("file_path", ""))
+            if not file_path_str:
+                return ToolExecResult(
+                    error="file_path parameter is required", error_code=-1
+                )
+
+            file_path = Path(file_path_str)
+            if not file_path.is_absolute():
+                return ToolExecResult(
+                    error=f"File path must be absolute: {file_path}", error_code=-1
+                )
+
+            json_path_arg = arguments.get("json_path")
+            if json_path_arg is not None and not isinstance(json_path_arg, str):
+                return ToolExecResult(
+                    error="json_path parameter must be a string.", error_code=-1
+                )
+
+            value = arguments.get("value")
+
+            pretty_print_arg = arguments.get("pretty_print", True)
+            if not isinstance(pretty_print_arg, bool):
+                return ToolExecResult(
+                    error="pretty_print parameter must be a boolean.", error_code=-1
+                )
+
+            if operation == "view":
+                return await self._view_json(file_path, json_path_arg, pretty_print_arg)
+
+            if not isinstance(json_path_arg, str):
+                return ToolExecResult(
+                    error=f"json_path parameter is required and must be a string for the '{operation}' operation.",
+                    error_code=-1,
+                )
+
+            if operation in ["set", "add"]:
+                if value is None:
+                    return ToolExecResult(
+                        error=f"A 'value' parameter is required for the '{operation}' operation.",
+                        error_code=-1,
+                    )
+                if operation == "set":
+                    return await self._set_json_value(
+                        file_path, json_path_arg, value, pretty_print_arg
+                    )
+                else:  # operation == "add"
+                    return await self._add_json_value(
+                        file_path, json_path_arg, value, pretty_print_arg
+                    )
+
+            if operation == "remove":
+                return await self._remove_json_value(
+                    file_path, json_path_arg, pretty_print_arg
+                )
+
+            return ToolExecResult(
+                error=f"Unknown operation: {operation}. Supported operations: view, set, add, remove",
+                error_code=-1,
+            )
+
+        except Exception as e:
+            return ToolExecResult(
+                error=f"JSON edit tool error: {str(e)}", error_code=-1
+            )
+
+    async def _load_json_file(self, file_path: Path) -> dict | list:
+        """Load and parse JSON file."""
+        if not file_path.exists():
+            raise ToolError(f"File does not exist: {file_path}")
+
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                content = f.read().strip()
+                if not content:
+                    raise ToolError(f"File is empty: {file_path}")
+                return json.loads(content)
+        except json.JSONDecodeError as e:
+            raise ToolError(f"Invalid JSON in file {file_path}: {str(e)}") from e
+        except Exception as e:
+            raise ToolError(f"Error reading file {file_path}: {str(e)}") from e
+
+    async def _save_json_file(
+        self, file_path: Path, data: dict | list, pretty_print: bool = True
+    ) -> None:
+        """Save JSON data to file."""
+        try:
+            with open(file_path, "w", encoding="utf-8") as f:
+                if pretty_print:
+                    json.dump(data, f, indent=2, ensure_ascii=False)
+                else:
+                    json.dump(data, f, ensure_ascii=False)
+        except Exception as e:
+            raise ToolError(f"Error writing to file {file_path}: {str(e)}") from e
+
+    def _parse_jsonpath(self, json_path_str: str):
+        """Parse JSONPath expression with error handling."""
+        try:
+            return jsonpath_parse(json_path_str)
+        except JSONPathError as e:
+            raise ToolError(
+                f"Invalid JSONPath expression '{json_path_str}': {str(e)}"
+            ) from e
+        except Exception as e:
+            raise ToolError(
+                f"Error parsing JSONPath '{json_path_str}': {str(e)}"
+            ) from e
+
+    async def _view_json(
+        self, file_path: Path, json_path_str: str | None, pretty_print: bool
+    ) -> ToolExecResult:
+        """View JSON file content or specific paths."""
+        data = await self._load_json_file(file_path)
+
+        if json_path_str:
+            jsonpath_expr = self._parse_jsonpath(json_path_str)
+            matches = jsonpath_expr.find(data)
+
+            if not matches:
+                return ToolExecResult(
+                    output=f"No matches found for JSONPath: {json_path_str}"
+                )
+
+            result_data = [match.value for match in matches]
+            if len(result_data) == 1:
+                result_data = result_data[0]
+
+            if pretty_print:
+                output = json.dumps(result_data, indent=2, ensure_ascii=False)
+            else:
+                output = json.dumps(result_data, ensure_ascii=False)
+
+            return ToolExecResult(
+                output=f"JSONPath '{json_path_str}' matches:\n{output}"
+            )
+        else:
+            if pretty_print:
+                output = json.dumps(data, indent=2, ensure_ascii=False)
+            else:
+                output = json.dumps(data, ensure_ascii=False)
+
+            return ToolExecResult(output=f"JSON content of {file_path}:\n{output}")
+
+    async def _set_json_value(
+        self, file_path: Path, json_path_str: str, value, pretty_print: bool
+    ) -> ToolExecResult:
+        """Set value at specified JSONPath."""
+        data = await self._load_json_file(file_path)
+        jsonpath_expr = self._parse_jsonpath(json_path_str)
+
+        matches = jsonpath_expr.find(data)
+        if not matches:
+            return ToolExecResult(
+                error=f"No matches found for JSONPath: {json_path_str}", error_code=-1
+            )
+
+        updated_data = jsonpath_expr.update(data, value)
+        await self._save_json_file(file_path, updated_data, pretty_print)
+
+        match_count = len(matches)
+        return ToolExecResult(
+            output=f"Successfully updated {match_count} location(s) at JSONPath '{json_path_str}' with value: {json.dumps(value)}"
+        )
+
+    async def _add_json_value(
+        self, file_path: Path, json_path_str: str, value, pretty_print: bool
+    ) -> ToolExecResult:
+        """Add value at specified JSONPath."""
+        data = await self._load_json_file(file_path)
+        jsonpath_expr = self._parse_jsonpath(json_path_str)
+
+        parent_path = jsonpath_expr.left
+        target = jsonpath_expr.right
+
+        parent_matches = parent_path.find(data)
+        if not parent_matches:
+            return ToolExecResult(
+                error=f"Parent path not found: {parent_path}", error_code=-1
+            )
+
+        for match in parent_matches:
+            parent_obj = match.value
+            if isinstance(target, Fields):
+                if not isinstance(parent_obj, dict):
+                    return ToolExecResult(
+                        error=f"Cannot add key to non-object at path: {parent_path}",
+                        error_code=-1,
+                    )
+                key_to_add = target.fields[0]
+                parent_obj[key_to_add] = value
+            elif isinstance(target, Index):
+                if not isinstance(parent_obj, list):
+                    return ToolExecResult(
+                        error=f"Cannot add element to non-array at path: {parent_path}",
+                        error_code=-1,
+                    )
+                index_to_add = target.index
+                parent_obj.insert(index_to_add, value)
+            else:
+                return ToolExecResult(
+                    error=f"Unsupported add operation for path type: {type(target)}. Path must end in a key or array index.",
+                    error_code=-1,
+                )
+
+        await self._save_json_file(file_path, data, pretty_print)
+        return ToolExecResult(
+            output=f"Successfully added value at JSONPath '{json_path_str}'"
+        )
+
+    async def _remove_json_value(
+        self, file_path: Path, json_path_str: str, pretty_print: bool
+    ) -> ToolExecResult:
+        """Remove value at specified JSONPath."""
+        data = await self._load_json_file(file_path)
+        jsonpath_expr = self._parse_jsonpath(json_path_str)
+
+        matches = jsonpath_expr.find(data)
+        if not matches:
+            return ToolExecResult(
+                error=f"No matches found for JSONPath: {json_path_str}", error_code=-1
+            )
+        match_count = len(matches)
+
+        for match in reversed(matches):
+            parent_path = match.full_path.left
+            target = match.path
+
+            parent_matches = parent_path.find(data)
+            if not parent_matches:
+                continue
+
+            for parent_match in parent_matches:
+                parent_obj = parent_match.value
+                try:
+                    if isinstance(target, Fields):
+                        key_to_remove = target.fields[0]
+                        if isinstance(parent_obj, dict) and key_to_remove in parent_obj:
+                            del parent_obj[key_to_remove]
+                    elif isinstance(target, Index):
+                        index_to_remove = target.index
+                        if isinstance(parent_obj, list) and -len(
+                            parent_obj
+                        ) <= index_to_remove < len(parent_obj):
+                            parent_obj.pop(index_to_remove)
+                except (KeyError, IndexError):
+                    pass
+
+        await self._save_json_file(file_path, data, pretty_print)
+        return ToolExecResult(
+            output=f"Successfully removed {match_count} element(s) at JSONPath '{json_path_str}'"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -578,6 +578,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonpath-ng"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ply" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/86/08646239a313f895186ff0a4573452038eed8c86f54380b3ebac34d32fb2/jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c", size = 37838, upload-time = "2024-10-11T15:41:42.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/5a/73ecb3d82f8615f32ccdadeb9356726d6cae3a4bbc840b437ceb95708063/jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6", size = 30105, upload-time = "2024-11-20T17:58:30.418Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -805,6 +817,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "ply"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
 ]
 
 [[package]]
@@ -1211,6 +1232,7 @@ dependencies = [
     { name = "anthropic" },
     { name = "click" },
     { name = "google-genai" },
+    { name = "jsonpath-ng" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -1238,6 +1260,7 @@ requires-dist = [
     { name = "datasets", marker = "extra == 'evaluation'", specifier = ">=3.6.0" },
     { name = "docker", marker = "extra == 'evaluation'", specifier = ">=7.1.0" },
     { name = "google-genai", specifier = ">=1.24.0" },
+    { name = "jsonpath-ng", specifier = ">=1.7.0" },
     { name = "openai", specifier = ">=1.86.0" },
     { name = "pre-commit", marker = "extra == 'test'", specifier = ">=4.2.0" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
This PR introduces the `JSONEditTool` for agents to perform structured edits on JSON files.

- Implemented `view`, `set`, `add`, and `remove` operations for JSON manipulation.
- Uses JSONPath expressions to target specific data within a file.
- Added error handling for missing files, invalid JSON content, and bad JSONPath expressions.
- Implemented as an `async` tool to integrate with the agent framework.
- Added new dependency `jsonpath-ng>=1.7.0`.
- Added unit tests (`TestJSONEditTool`) covering all operations and error paths.

It has been tested out with Gemini-2.5-Pro and I successfully executed it for a simple task

```
Using the json_edit_tool, please perform the following changes to the 'sample_data.json' file: 1. Change the 'status' from 'alpha' to 'beta'. 2. Add a new key named 'version' with the value '0.2.0' to the root of the object.
```
The gist for the logs: [trajectory_log](https://gist.github.com/rupaut98/689151e2f44056701d50777e06077661) (the log exceeds maximum character limit of a pull request).

Note: Make sure to implement https://github.com/bytedance/trae-agent/pull/68 to use Gemini models.(https://github.com/bytedance/trae-agent/issues/67)

This is a basic implementation and in the future I will be improvising on
1) Absolute and relative path handling with the json tool.
2) "add" operation needs to be revisited and implemented for complex json files.
3) "set" operation currently doesn't have an upsert functionality. That needs to be implemented
4) Filelocking needs to be introduced so multiple agents doesn't modify the same .json
5) The tool needs to atomically write to .json files instead of directly modifying the .json file.
6) The agent's execute method should be able to accept a list of operations instead of accepting only one operation. This way a batch of operations can be done simulataneously.
7) "view" operation can be expensive and have greater cognitive load if the json files are huge. A simple "get_schema" operation can be implemented that provides the file's schema reading the first few lines.
8) Introduce support for .jsonl files.