### PR TITLE
Added support for o4-mini model

### DIFF
--- a/trae_agent/utils/openai_client.py
+++ b/trae_agent/utils/openai_client.py
@@ -83,7 +83,7 @@ class OpenAIClient(BaseLLMClient):
                     model=model_parameters.model,
                     tools=tool_schemas if tool_schemas else openai.NOT_GIVEN,
                     temperature=model_parameters.temperature
-                    if "o3" not in model_parameters.model
+                    if "o3" not in model_parameters.model and "o4-mini" not in  model_parameters.model
                     else openai.NOT_GIVEN,
                     top_p=model_parameters.top_p,
                     max_output_tokens=model_parameters.max_tokens,

--- a/trae_agent/utils/openai_client.py
+++ b/trae_agent/utils/openai_client.py
@@ -83,7 +83,8 @@ class OpenAIClient(BaseLLMClient):
                     model=model_parameters.model,
                     tools=tool_schemas if tool_schemas else openai.NOT_GIVEN,
                     temperature=model_parameters.temperature
-                    if "o3" not in model_parameters.model and "o4-mini" not in  model_parameters.model
+                    if "o3" not in model_parameters.model
+                    and "o4-mini" not in model_parameters.model
                     else openai.NOT_GIVEN,
                     top_p=model_parameters.top_p,
                     max_output_tokens=model_parameters.max_tokens,


### PR DESCRIPTION
## Description
Added support for o4-mini model

## More Information

Both "o4-mini" and "o3" models do not support the temperature parameter. currently only for "o3" model the temperature param was not being added to the chat completions, but it was being added for "o4-mini" model. I made the slight change, to do the same for both. It checks if the model is not ("o3" and "o4-mini"), if it is not then temperature parameter is added, else openai.NOT_GIVEN is passed, as it was done before for "o3" model.

Note: since it was a very minor change thus unit tests were not needed

## Validation
Try running the trae-cli with provider as openai and model as o4-mini (already tested, it works)

ex:
trae-cli run "create a python script to print 'Hello world'" --provider openai --model o4-mini