### PR TITLE
Advising users to hide their API keys with dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ export OPENROUTER_SITE_URL="https://your-site.com"
 export OPENROUTER_SITE_NAME="Your App Name"
 ```
 
-While you can provide an `api_key` keyword argument, we recommend using [python-dotenv](https://pypi.org/project/python-dotenv/) to add `MODEL_API_KEY="My API Key"` to your `.env` file so that your API Key is not stored in source control.
+Although you can pass your API key directly using the `api_key` argument, we suggest utilizing [python-dotenv](https://pypi.org/project/python-dotenv/) to add `MODEL_API_KEY="My API Key"` to your `.env` file. This approach helps prevent your API key from being exposed in source control.
 
 ### Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ export OPENROUTER_SITE_URL="https://your-site.com"
 export OPENROUTER_SITE_NAME="Your App Name"
 ```
 
+While you can provide an `api_key` keyword argument, we recommend using [python-dotenv](https://pypi.org/project/python-dotenv/) to add `MODEL_API_KEY="My API Key"` to your `.env` file so that your API Key is not stored in source control.
+
 ### Basic Usage
 
 ```bash


### PR DESCRIPTION
## Description

Instead of hard coding API key into the Python program, add advice to user to use dotenv to hide their API keys.

## More Information

This pull request updates the documentation to recommend using [python-dotenv](https://pypi.org/project/python-dotenv/) for managing API keys. Users are now advised to store their API key in a `.env` file (e.g., `MODEL_API_KEY="My API Key"`) instead of placing it directly in the Python code. This approach helps to prevent accidental exposure of sensitive information in source control and follows security best practices.

N/A