### PR TITLE
Doubao base url warning in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ Trae Agent uses a JSON configuration file (`trae_config.json`) for settings:
   }
 }
 ```
+**WARNING:**
+For Doubao users, please use the following base_url.
+```
+base_url=https://ark.cn-beijing.volces.com/api/v3/
+```
 
 **Configuration Priority:**
 1. Command-line arguments (highest)


### PR DESCRIPTION
## Description
update the readme documentation and warn the user to use the base url. 

## More Information
This PR is suggested from the issue #64. The purpose is to avoid other using wrong base url. 

## Validation
N/A

## Linked Issues

#64