### PR TITLE
style: set ruff line-length to 100 instead of default 88

### DIFF
--- a/evaluation/swebench.py
+++ b/evaluation/swebench.py
@@ -76,9 +76,7 @@ class SWEBenchEvaluation:
 
         self.trae_config_file_name = trae_config_file_name
 
-        shutil.copyfile(
-            self.trae_config_file_name, self.working_dir / "trae_config_local.json"
-        )
+        shutil.copyfile(self.trae_config_file_name, self.working_dir / "trae_config_local.json")
 
         self.pull_images()
 
@@ -120,9 +118,7 @@ class SWEBenchEvaluation:
         self._check_images()
         print(f"Total number of images: {len(self.image_status)}")
         instance_ids = [
-            instance_id
-            for instance_id in self.image_status
-            if not self.image_status[instance_id]
+            instance_id for instance_id in self.image_status if not self.image_status[instance_id]
         ]
         print(f"Number of images to download: {len(instance_ids)}")
         if len(instance_ids) == 0:
@@ -158,9 +154,7 @@ class SWEBenchEvaluation:
             detach=True,
             tty=True,
             stdin_open=True,
-            volumes={
-                self.working_dir.absolute(): {"bind": "/trae-workspace", "mode": "rw"}
-            },
+            volumes={self.working_dir.absolute(): {"bind": "/trae-workspace", "mode": "rw"}},
             environment=self.docker_env_config.get("preparation_env", None),
         )
 
@@ -172,9 +166,7 @@ class SWEBenchEvaluation:
             "cd /trae-workspace/trae-agent && source $HOME/.local/bin/env && uv sync",
         ]
 
-        for command in tqdm(
-            commands, desc="Building trae-agent inside base Docker container"
-        ):
+        for command in tqdm(commands, desc="Building trae-agent inside base Docker container"):
             try:
                 new_command = f'/bin/bash -c "{command}"'
                 return_code, output = docker_exec(container, new_command)
@@ -228,9 +220,7 @@ class SWEBenchEvaluation:
             detach=True,
             tty=True,
             stdin_open=True,
-            volumes={
-                self.working_dir.absolute(): {"bind": "/trae-workspace", "mode": "rw"}
-            },
+            volumes={self.working_dir.absolute(): {"bind": "/trae-workspace", "mode": "rw"}},
             working_dir="/trae-workspace",
             environment=self.docker_env_config.get("experiment_env", None),
             stream=True,
@@ -321,9 +311,7 @@ class SWEBenchEvaluation:
             "latest",
         ]
 
-        process = subprocess.run(
-            cmd, capture_output=True, cwd=swebench_harness_path.as_posix()
-        )
+        process = subprocess.run(cmd, capture_output=True, cwd=swebench_harness_path.as_posix())
         print(process.stdout.decode())
         print(process.stderr.decode())
 
@@ -361,9 +349,7 @@ def main():
     argument_parser = argparse.ArgumentParser()
     argument_parser.add_argument("--dataset", type=str, default="SWE-bench_Verified")
     argument_parser.add_argument("--working-dir", type=str, default="./trae-workspace")
-    argument_parser.add_argument(
-        "--config-file", type=str, default="trae_config_local.json"
-    )
+    argument_parser.add_argument("--config-file", type=str, default="trae_config_local.json")
     argument_parser.add_argument(
         "--instance_ids",
         nargs="+",
@@ -377,9 +363,7 @@ def main():
         required=False,
         help="Only used for evaluation.",
     )
-    argument_parser.add_argument(
-        "--docker-env-config", type=str, default="", required=False
-    )
+    argument_parser.add_argument("--docker-env-config", type=str, default="", required=False)
     argument_parser.add_argument(
         "--run-id",
         type=str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,10 @@ exclude_lines = [
     "@(abc\\.)?abstractmethod",
 ]
 
+
+[tool.ruff]
+line-length = 100
+
 [tool.ruff.lint]
 select = [
     "B",

--- a/tests/tools/test_bash_tool.py
+++ b/tests/tools/test_bash_tool.py
@@ -23,14 +23,10 @@ class TestBashTool(unittest.IsolatedAsyncioTestCase):
         self.assertIn("restart", param_names)
 
     async def test_command_error_handling(self):
-        result = await self.tool.execute(
-            ToolCallArguments({"command": "invalid_command_123"})
-        )
+        result = await self.tool.execute(ToolCallArguments({"command": "invalid_command_123"}))
 
         # 修复断言：检查错误信息是否包含'not found'或'not recognized'（Windows系统）
-        self.assertTrue(
-            any(s in result.error.lower() for s in ["not found", "not recognized"])
-        )
+        self.assertTrue(any(s in result.error.lower() for s in ["not found", "not recognized"]))
 
     async def test_session_restart(self):
         # 确保会话已初始化
@@ -47,15 +43,11 @@ class TestBashTool(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(self.tool._session)
 
         # Verify new session works
-        result = await self.tool.execute(
-            ToolCallArguments({"command": "echo new session"})
-        )
+        result = await self.tool.execute(ToolCallArguments({"command": "echo new session"}))
         self.assertIn("new session", result.output)
 
     async def test_successful_command_execution(self):
-        result = await self.tool.execute(
-            ToolCallArguments({"command": "echo hello world"})
-        )
+        result = await self.tool.execute(ToolCallArguments({"command": "echo hello world"}))
 
         # 修复：检查返回码是否为0
         self.assertEqual(result.error_code, 0)

--- a/tests/tools/test_edit_tool.py
+++ b/tests/tools/test_edit_tool.py
@@ -62,9 +62,7 @@ class TestTextEditorTool(unittest.IsolatedAsyncioTestCase):
 
     async def test_invalid_command(self):
         result = await self.tool.execute(
-            ToolCallArguments(
-                {"command": "invalid", "path": str(self.test_file.absolute())}
-            )
+            ToolCallArguments({"command": "invalid", "path": str(self.test_file.absolute())})
         )
         self.assertEqual(result.error_code, -1)
         self.assertIn("Please provide a valid path", result.error)
@@ -101,9 +99,7 @@ class TestTextEditorTool(unittest.IsolatedAsyncioTestCase):
 
     async def test_view_directory(self):
         self.mock_file_system(exists=True, is_dir=True)
-        with patch(
-            "trae_agent.tools.edit_tool.run", new_callable=AsyncMock
-        ) as mock_run:
+        with patch("trae_agent.tools.edit_tool.run", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = (0, "file1\nfile2", "")
             result = await self.tool.execute(
                 ToolCallArguments({"command": "view", "path": str(self.test_dir)})

--- a/tests/utils/test_openrouter_client_utils.py
+++ b/tests/utils/test_openrouter_client_utils.py
@@ -98,13 +98,9 @@ class TestOpenRouterClient(unittest.TestCase):
             None,
         )
         openrouter_client = OpenRouterClient(model_parameters)
-        self.assertEqual(
-            openrouter_client.supports_tool_calling(model_parameters), True
-        )
+        self.assertEqual(openrouter_client.supports_tool_calling(model_parameters), True)
         model_parameters.model = "no such model"
-        self.assertEqual(
-            openrouter_client.supports_tool_calling(model_parameters), False
-        )
+        self.assertEqual(openrouter_client.supports_tool_calling(model_parameters), False)
 
 
 if __name__ == "__main__":

--- a/trae_agent/agent/base.py
+++ b/trae_agent/agent/base.py
@@ -22,9 +22,7 @@ class Agent(ABC):
             config.default_provider, config.model_providers[config.default_provider]
         )
         self.max_steps: int = config.max_steps
-        self.model_parameters: ModelParameters = config.model_providers[
-            config.default_provider
-        ]
+        self.model_parameters: ModelParameters = config.model_providers[config.default_provider]
         self.initial_messages: list[LLMMessage] = []
         self.task: str = ""
         self.tools: list[Tool] = []
@@ -78,9 +76,7 @@ class Agent(ABC):
                     if self.cli_console:
                         self.cli_console.update_status(step)
 
-                    llm_response = self.llm_client.chat(
-                        messages, self.model_parameters, self.tools
-                    )
+                    llm_response = self.llm_client.chat(messages, self.model_parameters, self.tools)
                     step.llm_response = llm_response
 
                     # Display step with LLM response
@@ -119,9 +115,7 @@ class Agent(ABC):
                         else:
                             step.state = AgentState.THINKING
                             messages = [
-                                LLMMessage(
-                                    role="user", content=self.task_incomplete_message()
-                                )
+                                LLMMessage(role="user", content=self.task_incomplete_message())
                             ]
                     else:
                         # Check if the response contains a tool call
@@ -137,16 +131,10 @@ class Agent(ABC):
                                 self.cli_console.update_status(step)
 
                             if self.model_parameters.parallel_tool_calls:
-                                tool_results = (
-                                    await self.tool_caller.parallel_tool_call(
-                                        tool_calls
-                                    )
-                                )
+                                tool_results = await self.tool_caller.parallel_tool_call(tool_calls)
                             else:
-                                tool_results = (
-                                    await self.tool_caller.sequential_tool_call(
-                                        tool_calls
-                                    )
+                                tool_results = await self.tool_caller.sequential_tool_call(
+                                    tool_calls
                                 )
                             step.tool_results = tool_results
 
@@ -157,9 +145,7 @@ class Agent(ABC):
                             messages = []
                             for tool_result in tool_results:
                                 # Add tool result to conversation
-                                message = LLMMessage(
-                                    role="user", tool_result=tool_result
-                                )
+                                message = LLMMessage(role="user", tool_result=tool_result)
                                 messages.append(message)
 
                             reflection = self.reflect_on_result(tool_results)
@@ -171,9 +157,7 @@ class Agent(ABC):
                                 if self.cli_console:
                                     self.cli_console.update_status(step)
 
-                                messages.append(
-                                    LLMMessage(role="assistant", content=reflection)
-                                )
+                                messages.append(LLMMessage(role="assistant", content=reflection))
                         else:
                             messages = [
                                 LLMMessage(
@@ -225,9 +209,7 @@ class Agent(ABC):
                     break
 
             if step_number > self.max_steps and not execution.success:
-                execution.final_result = (
-                    "Task execution exceeded maximum steps without completion."
-                )
+                execution.final_result = "Task execution exceeded maximum steps without completion."
 
         except Exception as e:
             execution.final_result = f"Agent execution failed: {str(e)}"

--- a/trae_agent/agent/trae_agent.py
+++ b/trae_agent/agent/trae_agent.py
@@ -74,15 +74,12 @@ class TraeAgent(Agent):
         # Get the model provider from the LLM client
         provider = self.llm_client.provider.value
         self.tools: list[Tool] = [
-            tools_registry[tool_name](model_provider=provider)
-            for tool_name in tool_names
+            tools_registry[tool_name](model_provider=provider) for tool_name in tool_names
         ]
         self.tool_caller: ToolExecutor = ToolExecutor(self.tools)
 
         self.initial_messages: list[LLMMessage] = []
-        self.initial_messages.append(
-            LLMMessage(role="system", content=self.get_system_prompt())
-        )
+        self.initial_messages.append(LLMMessage(role="system", content=self.get_system_prompt()))
 
         user_message = ""
         if not extra_args:
@@ -114,9 +111,7 @@ class TraeAgent(Agent):
     @override
     async def execute_task(self) -> AgentExecution:
         """Execute the task and finalize trajectory recording."""
-        console_task = (
-            asyncio.create_task(self.cli_console.start()) if self.cli_console else None
-        )
+        console_task = asyncio.create_task(self.cli_console.start()) if self.cli_console else None
         execution = await super().execute_task()
         if self.cli_console and console_task and not console_task.done():
             await console_task
@@ -240,9 +235,7 @@ If you are sure the issue has been solved, you should call the `task_done` to fi
         """Check if the LLM indicates that the task is completed."""
         if llm_response.tool_calls is None:
             return False
-        return any(
-            tool_call.name == "task_done" for tool_call in llm_response.tool_calls
-        )
+        return any(tool_call.name == "task_done" for tool_call in llm_response.tool_calls)
 
     @override
     def is_task_completed(self, llm_response: LLMResponse) -> bool:
@@ -258,6 +251,4 @@ If you are sure the issue has been solved, you should call the `task_done` to fi
     @override
     def task_incomplete_message(self) -> str:
         """Return a message indicating that the task is incomplete."""
-        return (
-            "ERROR! Your Patch is empty. Please provide a patch that fixes the problem."
-        )
+        return "ERROR! Your Patch is empty. Please provide a patch that fixes the problem."

--- a/trae_agent/cli.py
+++ b/trae_agent/cli.py
@@ -48,9 +48,7 @@ def load_config(
 
     config: Config = Config(config_file)
     # Resolve model provider
-    resolved_provider = (
-        resolve_config_value(provider, config.default_provider) or "openai"
-    )
+    resolved_provider = resolve_config_value(provider, config.default_provider) or "openai"
 
     config.default_provider = str(resolved_provider)
 
@@ -126,9 +124,7 @@ def cli():
 @click.option("--max-steps", help="Maximum number of execution steps", type=int)
 @click.option("--working-dir", "-w", help="Working directory for the agent")
 @click.option("--must-patch", "-mp", is_flag=True, help="Whether to patch the code")
-@click.option(
-    "--config-file", help="Path to configuration file", default="trae_config.json"
-)
+@click.option("--config-file", help="Path to configuration file", default="trae_config.json")
 @click.option("--trajectory-file", "-t", help="Path to save trajectory file")
 @click.option("--patch-path", "-pp", help="Path to patch file")
 def run(
@@ -209,9 +205,7 @@ def run(
     except KeyboardInterrupt:
         console.print("\n[yellow]Task execution interrupted by user[/yellow]")
         if trajectory_path:
-            console.print(
-                f"[blue]Partial trajectory saved to: {trajectory_path}[/blue]"
-            )
+            console.print(f"[blue]Partial trajectory saved to: {trajectory_path}[/blue]")
         sys.exit(1)
     except Exception as e:
         console.print(f"\n[red]Unexpected error: {e}[/red]")
@@ -225,12 +219,8 @@ def run(
 @click.option("--provider", "-p", help="LLM provider to use")
 @click.option("--model", "-m", help="Specific model to use")
 @click.option("--api-key", "-k", help="API key (or set via environment variable)")
-@click.option(
-    "--config-file", help="Path to configuration file", default="trae_config.json"
-)
-@click.option(
-    "--max-steps", help="Maximum number of execution steps", type=int, default=20
-)
+@click.option("--config-file", help="Path to configuration file", default="trae_config.json")
+@click.option("--max-steps", help="Maximum number of execution steps", type=int, default=20)
 @click.option("--trajectory-file", "-t", help="Path to save trajectory file")
 def interactive(
     provider: str | None = None,
@@ -245,9 +235,7 @@ def interactive(
     Args:
         tasks: the task that you want your agent to solve. This is required to be in the input
     """
-    config = load_config(
-        provider, model, api_key, config_file=config_file, max_steps=max_steps
-    )
+    config = load_config(provider, model, api_key, config_file=config_file, max_steps=max_steps)
 
     console.print(
         Panel(
@@ -312,9 +300,7 @@ def interactive(
             # Set up trajectory recording for this task
             trajectory_path = agent.setup_trajectory_recording(trajectory_file)
 
-            console.print(
-                f"[blue]Trajectory will be saved to: {trajectory_path}[/blue]"
-            )
+            console.print(f"[blue]Trajectory will be saved to: {trajectory_path}[/blue]")
 
             task_args = {
                 "project_path": working_dir,
@@ -341,9 +327,7 @@ def interactive(
 
 
 @cli.command()
-@click.option(
-    "--config-file", help="Path to configuration file", default="trae_config.json"
-)
+@click.option("--config-file", help="Path to configuration file", default="trae_config.json")
 def show_config(config_file: str):
     """Show current configuration settings."""
     config_path = Path(config_file)
@@ -377,9 +361,7 @@ Using default settings and environment variables.""",
         provider_table.add_column("Value", style="green")
 
         provider_table.add_row("Model", provider_config.model or "Not set")
-        provider_table.add_row(
-            "API Key", "Set" if provider_config.api_key else "Not set"
-        )
+        provider_table.add_row("API Key", "Set" if provider_config.api_key else "Not set")
         provider_table.add_row("Max Tokens", str(provider_config.max_tokens))
         provider_table.add_row("Temperature", str(provider_config.temperature))
         provider_table.add_row("Top P", str(provider_config.top_p))

--- a/trae_agent/tools/base.py
+++ b/trae_agent/tools/base.py
@@ -39,9 +39,7 @@ class ToolResult:
     id: str | None = None  # OpenAI-specific field
 
 
-ToolCallArguments = dict[
-    str, str | int | float | dict[str, object] | list[object] | None
-]
+ToolCallArguments = dict[str, str | int | float | dict[str, object] | list[object] | None]
 
 
 @dataclass
@@ -206,12 +204,8 @@ class ToolExecutor:
 
     async def parallel_tool_call(self, tool_calls: list[ToolCall]) -> list[ToolResult]:
         """Execute tool calls in parallel"""
-        return await asyncio.gather(
-            *[self.execute_tool_call(call) for call in tool_calls]
-        )
+        return await asyncio.gather(*[self.execute_tool_call(call) for call in tool_calls])
 
-    async def sequential_tool_call(
-        self, tool_calls: list[ToolCall]
-    ) -> list[ToolResult]:
+    async def sequential_tool_call(self, tool_calls: list[ToolCall]) -> list[ToolResult]:
         """Execute tool calls in sequential"""
         return [await self.execute_tool_call(call) for call in tool_calls]

--- a/trae_agent/tools/bash_tool.py
+++ b/trae_agent/tools/bash_tool.py
@@ -90,9 +90,7 @@ class _BashSession:
         assert self._process.stderr
 
         # send command to the process
-        self._process.stdin.write(
-            command.encode() + f"; echo '{self._sentinel}'\n".encode()
-        )
+        self._process.stdin.write(command.encode() + f"; echo '{self._sentinel}'\n".encode())
         await self._process.stdin.drain()
 
         # read output from the process, until the sentinel is found
@@ -120,9 +118,7 @@ class _BashSession:
         if error.endswith("\n"):
             error = error[:-1]
 
-        error_code = (
-            self._process.returncode if self._process.returncode is not None else 0
-        )
+        error_code = self._process.returncode if self._process.returncode is not None else 0
 
         # clear the buffers so that the next output can be read correctly
         self._process.stdout._buffer.clear()  # type: ignore[attr-defined]
@@ -196,9 +192,7 @@ class BashTool(Tool):
                 self._session = _BashSession()
                 await self._session.start()
             except Exception as e:
-                return ToolExecResult(
-                    error=f"Error starting bash session: {e}", error_code=-1
-                )
+                return ToolExecResult(error=f"Error starting bash session: {e}", error_code=-1)
 
         command = str(arguments["command"]) if "command" in arguments else None
         if command is None:
@@ -209,6 +203,4 @@ class BashTool(Tool):
         try:
             return await self._session.run(command)
         except Exception as e:
-            return ToolExecResult(
-                error=f"Error running bash command: {e}", error_code=-1
-            )
+            return ToolExecResult(error=f"Error running bash command: {e}", error_code=-1)

--- a/trae_agent/tools/edit_tool.py
+++ b/trae_agent/tools/edit_tool.py
@@ -120,16 +120,13 @@ Notes for using the `str_replace` command:
                 if view_range is None:
                     return await self.view(_path, None)
                 if not (
-                    isinstance(view_range, list)
-                    and all(isinstance(i, int) for i in view_range)
+                    isinstance(view_range, list) and all(isinstance(i, int) for i in view_range)
                 ):
                     return ToolExecResult(
                         error="Parameter `view_range` should be a list of integers.",
                         error_code=-1,
                     )
-                view_range_int: list[int] = [
-                    i for i in view_range if isinstance(i, int)
-                ]
+                view_range_int: list[int] = [i for i in view_range if isinstance(i, int)]
                 return await self.view(_path, view_range_int)
             elif command == "create":
                 file_text = arguments.get("file_text", None)
@@ -155,17 +152,13 @@ Notes for using the `str_replace` command:
                     )
                 return self.str_replace(_path, old_str, new_str)
             elif command == "insert":
-                insert_line = (
-                    arguments.get("insert_line") if "insert_line" in arguments else None
-                )
+                insert_line = arguments.get("insert_line") if "insert_line" in arguments else None
                 if not isinstance(insert_line, int):
                     return ToolExecResult(
                         error="Parameter `insert_line` is required and should be integer for command: insert",
                         error_code=-1,
                     )
-                new_str_to_insert = (
-                    arguments.get("new_str") if "new_str" in arguments else None
-                )
+                new_str_to_insert = arguments.get("new_str") if "new_str" in arguments else None
                 if not isinstance(new_str_to_insert, str):
                     return ToolExecResult(
                         error="Parameter `new_str` is required for command: insert",
@@ -189,9 +182,7 @@ Notes for using the `str_replace` command:
             )
         # Check if path exists
         if not path.exists() and command != "create":
-            raise ToolError(
-                f"The path {path} does not exist. Please provide a valid path."
-            )
+            raise ToolError(f"The path {path} does not exist. Please provide a valid path.")
         if path.exists() and command == "create":
             raise ToolError(
                 f"File already exists at: {path}. Cannot overwrite files using command `create`."
@@ -202,9 +193,7 @@ Notes for using the `str_replace` command:
                 f"The path {path} is a directory and only the `view` command can be used on directories"
             )
 
-    async def view(
-        self, path: Path, view_range: list[int] | None = None
-    ) -> ToolExecResult:
+    async def view(self, path: Path, view_range: list[int] | None = None) -> ToolExecResult:
         """Implement the view command"""
         if path.is_dir():
             if view_range:
@@ -212,9 +201,7 @@ Notes for using the `str_replace` command:
                     "The `view_range` parameter is not allowed when `path` points to a directory."
                 )
 
-            return_code, stdout, stderr = await run(
-                rf"find {path} -maxdepth 2 -not -path '*/\.*'"
-            )
+            return_code, stdout, stderr = await run(rf"find {path} -maxdepth 2 -not -path '*/\.*'")
             if not stderr:
                 stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
             return ToolExecResult(error_code=return_code, output=stdout, error=stderr)
@@ -223,9 +210,7 @@ Notes for using the `str_replace` command:
         init_line = 1
         if view_range:
             if len(view_range) != 2 or not all(isinstance(i, int) for i in view_range):  # pyright: ignore[reportUnnecessaryIsInstance]
-                raise ToolError(
-                    "Invalid `view_range`. It should be a list of two integers."
-                )
+                raise ToolError("Invalid `view_range`. It should be a list of two integers.")
             file_lines = file_content.split("\n")
             n_lines_file = len(file_lines)
             init_line, final_line = view_range
@@ -251,9 +236,7 @@ Notes for using the `str_replace` command:
             output=self._make_output(file_content, str(path), init_line=init_line)
         )
 
-    def str_replace(
-        self, path: Path, old_str: str, new_str: str | None
-    ) -> ToolExecResult:
+    def str_replace(self, path: Path, old_str: str, new_str: str | None) -> ToolExecResult:
         """Implement the str_replace command, which replaces old_str with new_str in the file content"""
         # Read the file content
         file_content = self.read_file(path).expandtabs()
@@ -268,11 +251,7 @@ Notes for using the `str_replace` command:
             )
         elif occurrences > 1:
             file_content_lines = file_content.split("\n")
-            lines = [
-                idx + 1
-                for idx, line in enumerate(file_content_lines)
-                if old_str in line
-            ]
+            lines = [idx + 1 for idx, line in enumerate(file_content_lines) if old_str in line]
             raise ToolError(
                 f"No replacement was performed. Multiple occurrences of old_str `{old_str}` in lines {lines}. Please ensure it is unique"
             )
@@ -291,9 +270,7 @@ Notes for using the `str_replace` command:
 
         # Prepare the success message
         success_msg = f"The file {path} has been edited. "
-        success_msg += self._make_output(
-            snippet, f"a snippet of {path}", start_line + 1
-        )
+        success_msg += self._make_output(snippet, f"a snippet of {path}", start_line + 1)
         success_msg += "Review the changes and make sure they are as expected. Edit the file again if necessary."
 
         return ToolExecResult(
@@ -314,9 +291,7 @@ Notes for using the `str_replace` command:
 
         new_str_lines = new_str.split("\n")
         new_file_text_lines = (
-            file_text_lines[:insert_line]
-            + new_str_lines
-            + file_text_lines[insert_line:]
+            file_text_lines[:insert_line] + new_str_lines + file_text_lines[insert_line:]
         )
         snippet_lines = (
             file_text_lines[max(0, insert_line - SNIPPET_LINES) : insert_line]
@@ -368,13 +343,8 @@ Notes for using the `str_replace` command:
         if expand_tabs:
             file_content = file_content.expandtabs()
         file_content = "\n".join(
-            [
-                f"{i + init_line:6}\t{line}"
-                for i, line in enumerate(file_content.split("\n"))
-            ]
+            [f"{i + init_line:6}\t{line}" for i, line in enumerate(file_content.split("\n"))]
         )
         return (
-            f"Here's the result of running `cat -n` on {file_descriptor}:\n"
-            + file_content
-            + "\n"
+            f"Here's the result of running `cat -n` on {file_descriptor}:\n" + file_content + "\n"
         )

--- a/trae_agent/tools/run.py
+++ b/trae_agent/tools/run.py
@@ -47,6 +47,4 @@ async def run(
     except asyncio.TimeoutError as exc:
         with contextlib.suppress(ProcessLookupError):
             process.kill()
-        raise TimeoutError(
-            f"Command '{cmd}' timed out after {timeout} seconds"
-        ) from exc
+        raise TimeoutError(f"Command '{cmd}' timed out after {timeout} seconds") from exc

--- a/trae_agent/tools/sequential_thinking_tool.py
+++ b/trae_agent/tools/sequential_thinking_tool.py
@@ -165,14 +165,10 @@ You should:
         if "thought" not in arguments or not isinstance(arguments["thought"], str):
             raise ValueError("Invalid thought: must be a string")
 
-        if "thought_number" not in arguments or not isinstance(
-            arguments["thought_number"], int
-        ):
+        if "thought_number" not in arguments or not isinstance(arguments["thought_number"], int):
             raise ValueError("Invalid thought_number: must be a number")
 
-        if "total_thoughts" not in arguments or not isinstance(
-            arguments["total_thoughts"], int
-        ):
+        if "total_thoughts" not in arguments or not isinstance(arguments["total_thoughts"], int):
             raise ValueError("Invalid total_thoughts: must be a number")
 
         if "next_thought_needed" not in arguments or not isinstance(
@@ -222,9 +218,7 @@ You should:
         thought = str(arguments["thought"])
         thought_number = int(arguments["thought_number"])  # Already validated as int
         total_thoughts = int(arguments["total_thoughts"])  # Already validated as int
-        next_thought_needed = bool(
-            arguments["next_thought_needed"]
-        )  # Already validated as bool
+        next_thought_needed = bool(arguments["next_thought_needed"])  # Already validated as bool
 
         # Handle optional fields with proper type checking
         is_revision = None
@@ -237,10 +231,7 @@ You should:
         if "branch_id" in arguments and arguments["branch_id"] is not None:
             branch_id = str(arguments["branch_id"])
 
-        if (
-            "needs_more_thoughts" in arguments
-            and arguments["needs_more_thoughts"] is not None
-        ):
+        if "needs_more_thoughts" in arguments and arguments["needs_more_thoughts"] is not None:
             needs_more_thoughts = bool(arguments["needs_more_thoughts"])
 
         return ThoughtData(
@@ -265,7 +256,9 @@ You should:
             context = f" (revising thought {thought_data.revises_thought})"
         elif thought_data.branch_from_thought:
             prefix = "🌿 Branch"
-            context = f" (from thought {thought_data.branch_from_thought}, ID: {thought_data.branch_id})"
+            context = (
+                f" (from thought {thought_data.branch_from_thought}, ID: {thought_data.branch_id})"
+            )
         else:
             prefix = "💭 Thought"
             context = ""

--- a/trae_agent/utils/anthropic_client.py
+++ b/trae_agent/utils/anthropic_client.py
@@ -51,14 +51,10 @@ class AnthropicClient(BaseLLMClient):
     ) -> LLMResponse:
         """Send chat messages to Anthropic with optional tool support."""
         # Convert messages to Anthropic format
-        anthropic_messages: list[anthropic.types.MessageParam] = self.parse_messages(
-            messages
-        )
+        anthropic_messages: list[anthropic.types.MessageParam] = self.parse_messages(messages)
 
         self.message_history = (
-            self.message_history + anthropic_messages
-            if reuse_history
-            else anthropic_messages
+            self.message_history + anthropic_messages if reuse_history else anthropic_messages
         )
 
         # Add tools if provided
@@ -77,9 +73,7 @@ class AnthropicClient(BaseLLMClient):
                     )
                 elif tool.name == "bash":
                     tool_schemas.append(
-                        anthropic.types.ToolBash20250124Param(
-                            name="bash", type="bash_20250124"
-                        )
+                        anthropic.types.ToolBash20250124Param(name="bash", type="bash_20250124")
                     )
                 else:
                     tool_schemas.append(
@@ -124,9 +118,7 @@ class AnthropicClient(BaseLLMClient):
             if content_block.type == "text":
                 content += content_block.text
                 self.message_history.append(
-                    anthropic.types.MessageParam(
-                        role="assistant", content=content_block.text
-                    )
+                    anthropic.types.MessageParam(role="assistant", content=content_block.text)
                 )
             elif content_block.type == "tool_use":
                 tool_calls.append(
@@ -137,9 +129,7 @@ class AnthropicClient(BaseLLMClient):
                     )
                 )
                 self.message_history.append(
-                    anthropic.types.MessageParam(
-                        role="assistant", content=[content_block]
-                    )
+                    anthropic.types.MessageParam(role="assistant", content=[content_block])
                 )
 
         usage = None
@@ -147,8 +137,7 @@ class AnthropicClient(BaseLLMClient):
             usage = LLMUsage(
                 input_tokens=response.usage.input_tokens,
                 output_tokens=response.usage.output_tokens,
-                cache_creation_input_tokens=response.usage.cache_creation_input_tokens
-                or 0,
+                cache_creation_input_tokens=response.usage.cache_creation_input_tokens or 0,
                 cache_read_input_tokens=response.usage.cache_read_input_tokens or 0,
             )
 
@@ -188,16 +177,12 @@ class AnthropicClient(BaseLLMClient):
         ]
         return any(model in model_parameters.model for model in tool_capable_models)
 
-    def parse_messages(
-        self, messages: list[LLMMessage]
-    ) -> list[anthropic.types.MessageParam]:
+    def parse_messages(self, messages: list[LLMMessage]) -> list[anthropic.types.MessageParam]:
         """Parse the messages to Anthropic format."""
         anthropic_messages: list[anthropic.types.MessageParam] = []
         for msg in messages:
             if msg.role == "system":
-                self.system_message = (
-                    msg.content if msg.content else anthropic.NOT_GIVEN
-                )
+                self.system_message = msg.content if msg.content else anthropic.NOT_GIVEN
             elif msg.tool_result:
                 anthropic_messages.append(
                     anthropic.types.MessageParam(

--- a/trae_agent/utils/azure_client.py
+++ b/trae_agent/utils/azure_client.py
@@ -176,9 +176,7 @@ class AzureClient(BaseLLMClient):
             )
         elif llm_response.content:
             self.message_history.append(
-                ChatCompletionAssistantMessageParam(
-                    content=llm_response.content, role="assistant"
-                )
+                ChatCompletionAssistantMessageParam(content=llm_response.content, role="assistant")
             )
 
         if self.trajectory_recorder:
@@ -196,9 +194,7 @@ class AzureClient(BaseLLMClient):
     def supports_tool_calling(self, model_parameters: ModelParameters) -> bool:
         return True
 
-    def parse_messages(
-        self, messages: list[LLMMessage]
-    ) -> list[ChatCompletionMessageParam]:
+    def parse_messages(self, messages: list[LLMMessage]) -> list[ChatCompletionMessageParam]:
         azure_messages: list[ChatCompletionMessageParam] = []
         for msg in messages:
             if msg.tool_call:
@@ -246,9 +242,7 @@ class AzureClient(BaseLLMClient):
                 if not msg.content:
                     raise ValueError("Assistant message content is required")
                 azure_messages.append(
-                    ChatCompletionAssistantMessageParam(
-                        content=msg.content, role="assistant"
-                    )
+                    ChatCompletionAssistantMessageParam(content=msg.content, role="assistant")
                 )
             else:
                 raise ValueError(f"Invalid message role: {msg.role}")

--- a/trae_agent/utils/base_client.py
+++ b/trae_agent/utils/base_client.py
@@ -17,9 +17,7 @@ class BaseLLMClient(ABC):
         self.api_key: str = model_parameters.api_key
         self.base_url: str | None = model_parameters.base_url
         self.api_version: str | None = model_parameters.api_version
-        self.trajectory_recorder: TrajectoryRecorder | None = (
-            None  # TrajectoryRecorder instance
-        )
+        self.trajectory_recorder: TrajectoryRecorder | None = None  # TrajectoryRecorder instance
 
     def set_trajectory_recorder(self, recorder: TrajectoryRecorder | None) -> None:
         """Set the trajectory recorder for this client."""

--- a/trae_agent/utils/cli_console.py
+++ b/trae_agent/utils/cli_console.py
@@ -40,9 +40,7 @@ class CLIConsole:
         self.config: Config | None = config
         self.console_steps: dict[int, ConsoleStep] = {}
         self.lakeview_config: LakeviewConfig | None = (
-            config.lakeview_config
-            if config is not None and config.enable_lakeview
-            else None
+            config.lakeview_config if config is not None and config.enable_lakeview else None
         )
         self.lake_view: LakeView | None = (
             LakeView(config) if config is not None and config.enable_lakeview else None
@@ -71,10 +69,7 @@ class CLIConsole:
                 self.lake_view is None
                 or (
                     len(self.agent_execution.steps) == len(self.console_steps)
-                    and all(
-                        step.lake_view_generator_done
-                        for step in self.console_steps.values()
-                    )
+                    and all(step.lake_view_generator_done for step in self.console_steps.values())
                 )
             ):
                 break
@@ -152,9 +147,7 @@ class CLIConsole:
             width=80,
         )
 
-    async def _create_lakeview_step_display(
-        self, agent_step: AgentStep
-    ) -> Panel | None:
+    async def _create_lakeview_step_display(self, agent_step: AgentStep) -> Panel | None:
         if self.lake_view is None:
             return None
 
@@ -180,9 +173,7 @@ class CLIConsole:
 
         # Build progressive step content
         step_content: list[str] = []
-        step_content.append(
-            f"[{color}]{emoji} State: {agent_step.state.value.title()}[/{color}]"
-        )
+        step_content.append(f"[{color}]{emoji} State: {agent_step.state.value.title()}[/{color}]")
 
         # Show LLM response if available (truncated for readability)
         if agent_step.llm_response and agent_step.llm_response.content:
@@ -202,11 +193,7 @@ class CLIConsole:
         if agent_step.tool_calls and agent_step.tool_results:
             step_content.append("\n[bold]📋 Tool Results:[/bold]")
             for i, result in enumerate(agent_step.tool_results):
-                status = (
-                    "[green]✅ Success[/green]"
-                    if result.success
-                    else "[red]❌ Failed[/red]"
-                )
+                status = "[green]✅ Success[/green]" if result.success else "[red]❌ Failed[/red]"
                 step_content.append(f"  {i + 1}. {status}")
                 if result.error:
                     step_content.append(f"     [red]Error:[/red] {result.error}")
@@ -215,9 +202,7 @@ class CLIConsole:
 
         # Show reflection
         if agent_step.reflection:
-            step_content.append(
-                f"\n[bold]💭 Reflection:[/bold]\n{agent_step.reflection}"
-            )
+            step_content.append(f"\n[bold]💭 Reflection:[/bold]\n{agent_step.reflection}")
 
         # Show error
         if agent_step.error:
@@ -234,15 +219,9 @@ class CLIConsole:
         panels: list[Panel] = []
         if self.agent_execution is None:
             previous_steps = (
-                self.agent_step_history[:-1]
-                if len(self.agent_step_history) >= 2
-                else []
+                self.agent_step_history[:-1] if len(self.agent_step_history) >= 2 else []
             )
-            current_step = (
-                self.agent_step_history[-1]
-                if len(self.agent_step_history) > 0
-                else None
-            )
+            current_step = self.agent_step_history[-1] if len(self.agent_step_history) > 0 else None
         else:
             previous_steps = self.agent_step_history
             current_step = None
@@ -257,9 +236,7 @@ class CLIConsole:
                         )
                     else:
                         lake_view_panel_generator = None
-                    self.console_steps[step_id] = ConsoleStep(
-                        panel, lake_view_panel_generator
-                    )
+                    self.console_steps[step_id] = ConsoleStep(panel, lake_view_panel_generator)
                     panels.append(panel)
                 else:
                     console_step = self.console_steps[step_id]
@@ -320,8 +297,7 @@ class CLIConsole:
 
         if execution.total_tokens:
             total_tokens = (
-                execution.total_tokens.input_tokens
-                + execution.total_tokens.output_tokens
+                execution.total_tokens.input_tokens + execution.total_tokens.output_tokens
             )
             table.add_row("Total Tokens", str(total_tokens))
             table.add_row("Input Tokens", str(execution.total_tokens.input_tokens))

--- a/trae_agent/utils/config.py
+++ b/trae_agent/utils/config.py
@@ -63,9 +63,7 @@ class Config:
                     with open(config_path, "r") as f:
                         self._config = json.load(f)
                 except Exception as e:
-                    print(
-                        f"Warning: Could not load config file {config_or_config_file}: {e}"
-                    )
+                    print(f"Warning: Could not load config file {config_or_config_file}: {e}")
                     self._config = {}
             else:
                 self._config = {}
@@ -90,9 +88,9 @@ class Config:
             }
         else:
             for provider in self._config.get("model_providers", {}):
-                provider_config: dict[str, Any] = self._config.get(
-                    "model_providers", {}
-                ).get(provider, {})
+                provider_config: dict[str, Any] = self._config.get("model_providers", {}).get(
+                    provider, {}
+                )
 
                 candidate_count = provider_config.get("candidate_count")
                 self.model_providers[provider] = ModelParameters(
@@ -103,18 +101,14 @@ class Config:
                     top_p=float(provider_config.get("top_p", 1)),
                     top_k=int(provider_config.get("top_k", 0)),
                     max_retries=int(provider_config.get("max_retries", 10)),
-                    parallel_tool_calls=bool(
-                        provider_config.get("parallel_tool_calls", False)
-                    ),
+                    parallel_tool_calls=bool(provider_config.get("parallel_tool_calls", False)),
                     base_url=str(provider_config.get("base_url"))
                     if "base_url" in provider_config
                     else None,
                     api_version=str(provider_config.get("api_version"))
                     if "api_version" in provider_config
                     else None,
-                    candidate_count=int(candidate_count)
-                    if candidate_count is not None
-                    else None,
+                    candidate_count=int(candidate_count) if candidate_count is not None else None,
                     stop_sequences=provider_config.get("stop_sequences")
                     if "stop_sequences" in provider_config
                     else None,
@@ -123,9 +117,7 @@ class Config:
         if "lakeview_config" in self._config:
             self.lakeview_config = LakeviewConfig(
                 model_provider=str(
-                    self._config.get("lakeview_config", {}).get(
-                        "model_provider", "anthropic"
-                    )
+                    self._config.get("lakeview_config", {}).get("model_provider", "anthropic")
                 ),
                 model_name=str(
                     self._config.get("lakeview_config", {}).get(

--- a/trae_agent/utils/doubao_client.py
+++ b/trae_agent/utils/doubao_client.py
@@ -59,9 +59,7 @@ class DoubaoClient(BaseLLMClient):
         # if self.api_version is None:
         #     raise ValueError("Doubao API version not provided. ")
 
-        self.client: openai.OpenAI = openai.OpenAI(
-            base_url=self.base_url, api_key=self.api_key
-        )
+        self.client: openai.OpenAI = openai.OpenAI(base_url=self.base_url, api_key=self.api_key)
         self.message_history: list[ChatCompletionMessageParam] = []
 
     @override
@@ -174,9 +172,7 @@ class DoubaoClient(BaseLLMClient):
             )
         elif llm_response.content:
             self.message_history.append(
-                ChatCompletionAssistantMessageParam(
-                    content=llm_response.content, role="assistant"
-                )
+                ChatCompletionAssistantMessageParam(content=llm_response.content, role="assistant")
             )
 
         if self.trajectory_recorder:
@@ -194,9 +190,7 @@ class DoubaoClient(BaseLLMClient):
     def supports_tool_calling(self, model_parameters: ModelParameters) -> bool:
         return True
 
-    def parse_messages(
-        self, messages: list[LLMMessage]
-    ) -> list[ChatCompletionMessageParam]:
+    def parse_messages(self, messages: list[LLMMessage]) -> list[ChatCompletionMessageParam]:
         doubao_messages: list[ChatCompletionMessageParam] = []
         for msg in messages:
             if msg.tool_call:
@@ -244,9 +238,7 @@ class DoubaoClient(BaseLLMClient):
                 if not msg.content:
                     raise ValueError("Assistant message content is required")
                 doubao_messages.append(
-                    ChatCompletionAssistantMessageParam(
-                        content=msg.content, role="assistant"
-                    )
+                    ChatCompletionAssistantMessageParam(content=msg.content, role="assistant")
                 )
             else:
                 raise ValueError(f"Invalid message role: {msg.role}")

--- a/trae_agent/utils/lake_view.py
+++ b/trae_agent/utils/lake_view.py
@@ -106,9 +106,7 @@ class LakeView:
 
         return " · ".join([KNOWN_TAGS[tag] + tag if emoji else tag for tag in tags])
 
-    async def extract_task_in_step(
-        self, prev_step: str, this_step: str
-    ) -> tuple[str, str]:
+    async def extract_task_in_step(self, prev_step: str, this_step: str) -> tuple[str, str]:
         llm_messages = [
             LLMMessage(
                 role="user",
@@ -133,9 +131,7 @@ class LakeView:
 
         retry = 0
         while retry < 10 and (
-            "</task>" not in content
-            or "<details>" not in content
-            or "</details>" not in content
+            "</task>" not in content or "<details>" not in content or "</details>" not in content
         ):
             retry += 1
             llm_response = self.lakeview_llm_client.chat(
@@ -145,11 +141,7 @@ class LakeView:
             )
             content = llm_response.content.strip()
 
-        if (
-            "</task>" not in content
-            or "<details>" not in content
-            or "</details>" not in content
-        ):
+        if "</task>" not in content or "<details>" not in content or "</details>" not in content:
             return "", ""
 
         desc_task, _, desc_details = content.rpartition("</task>")
@@ -160,8 +152,7 @@ class LakeView:
 
     async def extract_tag_in_step(self, step: str) -> list[str]:
         steps_fmt = "\n\n".join(
-            f'<step id="{ind + 1}">\n{s.strip()}\n</step>'
-            for ind, s in enumerate(self.steps)
+            f'<step id="{ind + 1}">\n{s.strip()}\n</step>' for ind, s in enumerate(self.steps)
         )
 
         if len(steps_fmt) > 300_000:

--- a/trae_agent/utils/llm_basics.py
+++ b/trae_agent/utils/llm_basics.py
@@ -34,8 +34,7 @@ class LLMUsage:
             output_tokens=self.output_tokens + other.output_tokens,
             cache_creation_input_tokens=self.cache_creation_input_tokens
             + other.cache_creation_input_tokens,
-            cache_read_input_tokens=self.cache_read_input_tokens
-            + other.cache_read_input_tokens,
+            cache_read_input_tokens=self.cache_read_input_tokens + other.cache_read_input_tokens,
             reasoning_tokens=self.reasoning_tokens + other.reasoning_tokens,
         )
 

--- a/trae_agent/utils/llm_client.py
+++ b/trae_agent/utils/llm_client.py
@@ -83,6 +83,6 @@ class LLMClient:
 
     def supports_tool_calling(self, model_parameters: ModelParameters) -> bool:
         """Check if the current client supports tool calling."""
-        return hasattr(
-            self.client, "supports_tool_calling"
-        ) and self.client.supports_tool_calling(model_parameters)
+        return hasattr(self.client, "supports_tool_calling") and self.client.supports_tool_calling(
+            model_parameters
+        )

--- a/trae_agent/utils/ollama_client.py
+++ b/trae_agent/utils/ollama_client.py
@@ -216,9 +216,7 @@ class OllamaClient(BaseLLMClient):
                 elif msg.role == "user":
                     openai_messages.append({"role": "user", "content": msg.content})
                 elif msg.role == "assistant":
-                    openai_messages.append(
-                        {"role": "assistant", "content": msg.content}
-                    )
+                    openai_messages.append({"role": "assistant", "content": msg.content})
                 else:
                     raise ValueError(f"Invalid message role: {msg.role}")
         return openai_messages
@@ -232,9 +230,7 @@ class OllamaClient(BaseLLMClient):
             type="function_call",
         )
 
-    def parse_tool_call_result(
-        self, tool_call_result: ToolResult
-    ) -> FunctionCallOutput:
+    def parse_tool_call_result(self, tool_call_result: ToolResult) -> FunctionCallOutput:
         """Parse the tool call result from the LLM response."""
         result: str = ""
         if tool_call_result.result:

--- a/trae_agent/utils/openai_client.py
+++ b/trae_agent/utils/openai_client.py
@@ -189,9 +189,7 @@ class OpenAIClient(BaseLLMClient):
                 elif msg.role == "user":
                     openai_messages.append({"role": "user", "content": msg.content})
                 elif msg.role == "assistant":
-                    openai_messages.append(
-                        {"role": "assistant", "content": msg.content}
-                    )
+                    openai_messages.append({"role": "assistant", "content": msg.content})
                 else:
                     raise ValueError(f"Invalid message role: {msg.role}")
         return openai_messages
@@ -205,9 +203,7 @@ class OpenAIClient(BaseLLMClient):
             type="function_call",
         )
 
-    def parse_tool_call_result(
-        self, tool_call_result: ToolResult
-    ) -> FunctionCallOutput:
+    def parse_tool_call_result(self, tool_call_result: ToolResult) -> FunctionCallOutput:
         """Parse the tool call result from the LLM response to FunctionCallOutput format."""
         result_content: str = ""
         if tool_call_result.result is not None:

--- a/trae_agent/utils/openrouter_client.py
+++ b/trae_agent/utils/openrouter_client.py
@@ -173,9 +173,7 @@ class OpenRouterClient(BaseLLMClient):
             )
         elif llm_response.content:
             self.message_history.append(
-                ChatCompletionAssistantMessageParam(
-                    content=llm_response.content, role="assistant"
-                )
+                ChatCompletionAssistantMessageParam(content=llm_response.content, role="assistant")
             )
 
         if self.trajectory_recorder:
@@ -204,14 +202,9 @@ class OpenRouterClient(BaseLLMClient):
             "llama-3",
             "command-r",
         ]
-        return any(
-            pattern in model_parameters.model.lower()
-            for pattern in tool_capable_patterns
-        )
+        return any(pattern in model_parameters.model.lower() for pattern in tool_capable_patterns)
 
-    def parse_messages(
-        self, messages: list[LLMMessage]
-    ) -> list[ChatCompletionMessageParam]:
+    def parse_messages(self, messages: list[LLMMessage]) -> list[ChatCompletionMessageParam]:
         openrouter_messages: list[ChatCompletionMessageParam] = []
         for msg in messages:
             if msg.tool_call:
@@ -259,9 +252,7 @@ class OpenRouterClient(BaseLLMClient):
                 if not msg.content:
                     raise ValueError("Assistant message content is required")
                 openrouter_messages.append(
-                    ChatCompletionAssistantMessageParam(
-                        content=msg.content, role="assistant"
-                    )
+                    ChatCompletionAssistantMessageParam(content=msg.content, role="assistant")
                 )
             else:
                 raise ValueError(f"Invalid message role: {msg.role}")

--- a/trae_agent/utils/trajectory_recorder.py
+++ b/trae_agent/utils/trajectory_recorder.py
@@ -46,9 +46,7 @@ class TrajectoryRecorder:
         }
         self._start_time: datetime | None = None
 
-    def start_recording(
-        self, task: str, provider: str, model: str, max_steps: int
-    ) -> None:
+    def start_recording(self, task: str, provider: str, model: str, max_steps: int) -> None:
         """Start recording a new trajectory.
 
         Args:
@@ -98,12 +96,8 @@ class TrajectoryRecorder:
                 "model": response.model,
                 "finish_reason": response.finish_reason,
                 "usage": {
-                    "input_tokens": response.usage.input_tokens
-                    if response.usage
-                    else None,
-                    "output_tokens": response.usage.output_tokens
-                    if response.usage
-                    else None,
+                    "input_tokens": response.usage.input_tokens if response.usage else None,
+                    "output_tokens": response.usage.output_tokens if response.usage else None,
                     "cache_creation_input_tokens": getattr(
                         response.usage, "cache_creation_input_tokens", None
                     )
@@ -114,15 +108,11 @@ class TrajectoryRecorder:
                     )
                     if response.usage
                     else None,
-                    "reasoning_tokens": getattr(
-                        response.usage, "reasoning_tokens", None
-                    )
+                    "reasoning_tokens": getattr(response.usage, "reasoning_tokens", None)
                     if response.usage
                     else None,
                 },
-                "tool_calls": [
-                    self._serialize_tool_call(tc) for tc in response.tool_calls
-                ]
+                "tool_calls": [self._serialize_tool_call(tc) for tc in response.tool_calls]
                 if response.tool_calls
                 else None,
             },
@@ -167,18 +157,14 @@ class TrajectoryRecorder:
                 "model": llm_response.model,
                 "finish_reason": llm_response.finish_reason,
                 "usage": {
-                    "input_tokens": llm_response.usage.input_tokens
-                    if llm_response.usage
-                    else None,
+                    "input_tokens": llm_response.usage.input_tokens if llm_response.usage else None,
                     "output_tokens": llm_response.usage.output_tokens
                     if llm_response.usage
                     else None,
                 }
                 if llm_response.usage
                 else None,
-                "tool_calls": [
-                    self._serialize_tool_call(tc) for tc in llm_response.tool_calls
-                ]
+                "tool_calls": [self._serialize_tool_call(tc) for tc in llm_response.tool_calls]
                 if llm_response.tool_calls
                 else None,
             }
@@ -197,9 +183,7 @@ class TrajectoryRecorder:
         self.trajectory_data["agent_steps"].append(step_data)
         self.save_trajectory()
 
-    def finalize_recording(
-        self, success: bool, final_result: str | None = None
-    ) -> None:
+    def finalize_recording(self, success: bool, final_result: str | None = None) -> None:
         """Finalize the trajectory recording.
 
         Args:


### PR DESCRIPTION
## Description

Ruff's default line-length of 88 is not well-suited for modern monitors, which makes the formatted code look somewhat wired. For example:

https://github.com/bytedance/trae-agent/blob/1bf5f717a4bb93c18d1b312d373b2f02103c4590/trae_agent/utils/config.py#L98-L120

Each parameter setting requires three lines:
```
     api_version=str(provider_config.get("api_version")) 
     if "api_version" in provider_config 
     else None, 
```

It would be much better if we set the default line-length to a higher value of 100, which would reduce many unnecessary line breaks.

This PR contains two commits:
- 873f0b3a764471d8dafbb311855453ffadb3aad3: set ruff line-length to 100 instead of default
- 93d490757d74f2e6f363c3e56107326ca5d90b5b: using ruff to reformat the codebase
