### PR TITLE
feat(readme-json-tool): added json tool info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ Trae Agent comes with several built-in tools:
   - Mark tasks as successfully completed
   - Provide final results and summaries
 
+- **json_edit_tool**: Edit and manipulate JSON files
+  - `view` - Display the entire JSON file or content at specific JSONPaths
+  - `set` - Update existing values at specified JSONPaths
+  - `add` - Add new key-value pairs to objects or append elements to arrays at a given JSONPath
+  - `remove` - Delete elements at specified JSONPaths
+
 ## 📊 Trajectory Recording
 
 Trae Agent automatically records detailed execution trajectories for debugging and analysis:


### PR DESCRIPTION
As the new ```JSONEditTool``` has been merged https://github.com/bytedance/trae-agent/pull/69. This PR adds info about the new tool so the users are aware of it. 