### PR TITLE
CI: Enable users to execute the CI process with a local repository. 

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   pre-commit:
 
-    if: github.repository == 'bytedance/trae-agent'
     runs-on: ubuntu-latest
     name: Pre-commit checks
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   test:
-    if: github.repository == 'bytedance/trae-agent'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description

Currently, users cannot test whether they pass the CI locally because of the if statement in the workflow. Removing this condition will allow users to run the CI tests locally and still enable maintainers to run the CI on the bytedance/trae-agent repository.

## More Information

N/A

## Validation
No validation is needed as the code is just the same other then remove the if statement. 

## Linked Issues
N/A