### PR TITLE
Bugfix: reoganise configuration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ export ANTHROPIC_API_KEY="your-anthropic-api-key"
 
 # For Doubao (also works with other OpenAI-compatible model providers)
 export DOUBAO_API_KEY="your-doubao-api-key"
-export DOUBAO_API_BASE_URL="your-model-provider-base-url"
+export DOUBAO_BASE_URL="your-model-provider-base-url"
 
 # For OpenRouter
 export OPENROUTER_API_KEY="your-openrouter-api-key"

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
 # SPDX-License-Identifier: MIT
 
-import os
 import unittest
 from unittest.mock import patch
 
@@ -128,30 +127,6 @@ class TestConfigBaseURL(unittest.TestCase):
             api_key="test-api-key", base_url="https://custom-openai.example.com/v1"
         )
         self.assertEqual(client.base_url, "https://custom-openai.example.com/v1")
-
-    @patch("trae_agent.utils.openai_client.openai.OpenAI")
-    def test_openai_client_with_environment_base_url(self, mock_openai):
-        model_params = ModelParameters(
-            model="gpt-4o",
-            api_key="test-api-key",
-            base_url="https://api.openai.com/v1",  # original config
-            max_tokens=4096,
-            temperature=0.5,
-            top_p=1,
-            top_k=0,
-            parallel_tool_calls=False,
-            max_retries=10,
-        )
-
-        # when env variable is set, the base_url should be the env variable
-        with patch.dict(os.environ, {"OPENAI_BASE_URL": "https://env-openai.example.com/v1"}):
-            client = OpenAIClient(model_params)
-
-            mock_openai.assert_called_once_with(
-                api_key="test-api-key", base_url="https://env-openai.example.com/v1"
-            )
-
-            self.assertEqual(client.base_url, "https://env-openai.example.com/v1")
 
     @patch("trae_agent.utils.anthropic_client.anthropic.Anthropic")
     def test_anthropic_client_base_url_attribute_set(self, mock_anthropic):

--- a/trae_agent/utils/anthropic_client.py
+++ b/trae_agent/utils/anthropic_client.py
@@ -4,7 +4,6 @@
 """Anthropic API client wrapper with tool integration."""
 
 import json
-import os
 import random
 import time
 from typing import override
@@ -23,14 +22,6 @@ class AnthropicClient(BaseLLMClient):
 
     def __init__(self, model_parameters: ModelParameters):
         super().__init__(model_parameters)
-
-        if self.api_key == "":
-            self.api_key: str = os.getenv("ANTHROPIC_API_KEY", "")
-
-        if self.api_key == "":
-            raise ValueError(
-                "Anthropic API key not provided. Set ANTHROPIC_API_KEY in environment variables or config file."
-            )
 
         self.client: anthropic.Anthropic = anthropic.Anthropic(
             api_key=self.api_key, base_url=self.base_url

--- a/trae_agent/utils/azure_client.py
+++ b/trae_agent/utils/azure_client.py
@@ -4,7 +4,6 @@
 """Azure client wrapper with tool integrations"""
 
 import json
-import os
 import random
 import time
 from typing import override
@@ -36,28 +35,6 @@ class AzureClient(BaseLLMClient):
 
     def __init__(self, model_parameters: ModelParameters):
         super().__init__(model_parameters)
-
-        if self.api_key == "":
-            self.api_key: str = os.getenv("AZURE_API_KEY", "")
-
-        if self.api_key == "":
-            raise ValueError(
-                "Azure API key not provided. Set AZURE_API_KEY in environment variables or config file."
-            )
-
-        if self.base_url is None or self.base_url == "":
-            self.base_url: str | None = os.getenv("AZURE_API_BASE_URL")
-
-        if self.base_url is None:
-            raise ValueError(
-                "Azure API base url not provided. Set AZURE_API_BASE_URL in environment variables or config file."
-            )
-
-        if self.api_version is None or self.api_version == "":
-            self.api_version: str | None = os.getenv("AZURE_API_VERSION")
-
-        if self.api_version is None:
-            raise ValueError("Azure API version not provided. ")
 
         self.client: openai.AzureOpenAI = openai.AzureOpenAI(
             azure_endpoint=self.base_url,

--- a/trae_agent/utils/doubao_client.py
+++ b/trae_agent/utils/doubao_client.py
@@ -4,7 +4,6 @@
 """Doubao client wrapper with tool integrations"""
 
 import json
-import os
 import random
 import time
 from typing import override
@@ -36,29 +35,6 @@ class DoubaoClient(BaseLLMClient):
 
     def __init__(self, model_parameters: ModelParameters):
         super().__init__(model_parameters)
-
-        if self.api_key == "":
-            self.api_key: str = os.getenv("DOUBAO_API_KEY", "")
-
-        if self.api_key == "":
-            raise ValueError(
-                "Doubao API key not provided. Set DOUBAO_API_KEY in environment variables or config file."
-            )
-
-        if self.base_url is None or self.base_url == "":
-            self.base_url: str | None = os.getenv("DOUBAO_API_BASE_URL")
-
-        if self.base_url is None:
-            raise ValueError(
-                "Doubao API base url not provided. Set DOUBAO_API_BASE_URL in environment variables or config file."
-            )
-
-        # if self.api_version is None or self.api_version == "":
-        #     self.api_version: str | None = os.getenv("DOUBAO_API_VERSION")
-
-        # if self.api_version is None:
-        #     raise ValueError("Doubao API version not provided. ")
-
         self.client: openai.OpenAI = openai.OpenAI(base_url=self.base_url, api_key=self.api_key)
         self.message_history: list[ChatCompletionMessageParam] = []
 

--- a/trae_agent/utils/google_client.py
+++ b/trae_agent/utils/google_client.py
@@ -4,7 +4,6 @@
 """Google Gemini API client wrapper with tool integration."""
 
 import json
-import os
 import random
 import time
 import traceback
@@ -25,16 +24,6 @@ class GoogleClient(BaseLLMClient):
 
     def __init__(self, model_parameters: ModelParameters):
         super().__init__(model_parameters)
-
-        if self.api_key == "":
-            google_api_key = os.getenv("GOOGLE_API_KEY")
-            if google_api_key:
-                self.api_key = google_api_key
-
-        if self.api_key == "":
-            raise ValueError(
-                "Google API key not provided. Set GOOGLE_API_KEY in environment variables or config file."
-            )
 
         self.client = genai.Client(api_key=self.api_key)
         self.message_history: list[types.Content] = []

--- a/trae_agent/utils/ollama_client.py
+++ b/trae_agent/utils/ollama_client.py
@@ -30,9 +30,6 @@ class OllamaClient(BaseLLMClient):
     def __init__(self, model_parameters: ModelParameters):
         super().__init__(model_parameters)
 
-        # ollama default api key is ollama
-        self.api_key = "ollama"
-
         self.client: openai.OpenAI = openai.OpenAI(
             # by default ollama doesn't require any api key. It should set to be "ollama".
             api_key=self.api_key,

--- a/trae_agent/utils/openai_client.py
+++ b/trae_agent/utils/openai_client.py
@@ -4,7 +4,6 @@
 """OpenAI API client wrapper with tool integration."""
 
 import json
-import os
 import random
 import time
 from typing import override
@@ -28,19 +27,6 @@ class OpenAIClient(BaseLLMClient):
 
     def __init__(self, model_parameters: ModelParameters):
         super().__init__(model_parameters)
-
-        if self.api_key == "":
-            self.api_key: str = os.getenv("OPENAI_API_KEY", "")
-
-        if self.api_key == "":
-            raise ValueError(
-                "OpenAI API key not provided. Set OPENAI_API_KEY in environment variables or config file."
-            )
-
-        if "OPENAI_BASE_URL" in os.environ:
-            # If OPENAI_BASE_URL is set, which means the user wants to use a specific openai compatible api provider,
-            # we should use the base url from the environment variable
-            self.base_url = os.environ["OPENAI_BASE_URL"]
 
         self.client: openai.OpenAI = openai.OpenAI(api_key=self.api_key, base_url=self.base_url)
         self.message_history: ResponseInputParam = []

--- a/trae_agent/utils/openrouter_client.py
+++ b/trae_agent/utils/openrouter_client.py
@@ -37,14 +37,6 @@ class OpenRouterClient(BaseLLMClient):
     def __init__(self, model_parameters: ModelParameters):
         super().__init__(model_parameters)
 
-        if self.api_key == "":
-            self.api_key: str = os.getenv("OPENROUTER_API_KEY", "")
-
-        if self.api_key == "":
-            raise ValueError(
-                "OpenRouter API key not provided. Set OPENROUTER_API_KEY in environment variables or config file."
-            )
-
         # Use OpenAI SDK with OpenRouter's base URL
         self.client: openai.OpenAI = openai.OpenAI(api_key=self.api_key, base_url=self.base_url)
         self.message_history: list[ChatCompletionMessageParam] = []


### PR DESCRIPTION
## Description

The fix comes from a bug report, where Doubao api key and base url are set, but when calling the model, it uses the 'doubao_base_url' as the base_url, which comes from the default settings.

In addition, currently, all clients have same code to read API keys and URLs from the env, which should be done during configuration.

## More Information

## Validation

All tests passed.

## Linked Issues

Online report.