### PR TITLE
feat: handling dangerous command. 

### DIFF
--- a/trae_agent/tools/bash_tool.py
+++ b/trae_agent/tools/bash_tool.py
@@ -191,7 +191,7 @@ class BashTool(Tool):
         command = str(arguments["command"]) if "command" in arguments else None
         if arguments.get("dangerous") and not self.sudo:
             allow = Prompt.ask(
-                f'Command "{command}" is considered dangerous. Are you sure you want to allow the agent to run this command? [Y/N/D] \n Y: Yes , N: No , D: Always Allow'
+                f'Command "{command}" is considered dangerous. Are you sure you want to allow the agent to run this command? [Y/N/A] \n Y: Yes , N: No , A: Always Allow'
             )
 
             if allow != "Y" and allow != "A":


### PR DESCRIPTION
## Description
When performing a dangerous command, the agent will ask the user for permission before proceeding. There is also an "always allow" option.

## More Information
N/A

## Validation
Able to run with open router model and Ollama model. 

## Linked Issues
#122 