### PR TITLE
feat(trajectory-recorder): Organize trajectory paths and fix long prompt errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - 🤖 **Multi-LLM Support**: Works with OpenAI, Anthropic, Doubao, Azure, OpenRouter, Ollama and Google Gemini APIs
 - 🛠️ **Rich Tool Ecosystem**: File editing, bash execution, sequential thinking, and more
 - 🎯 **Interactive Mode**: Conversational interface for iterative development
-- 📊 **Trajectory Recording**: Detailed logging of all agent actions for debugging and analysis
+- 📊 **Trajectory Recording**: Organized Trajectory Recording: Detailed logs of all agent actions, organized by provider and date for easy analysis.
 - ⚙️ **Flexible Configuration**: JSON-based configuration with environment variable support
 - 🚀 **Easy Installation**: Simple pip-based installation
 
@@ -113,8 +113,8 @@ trae-cli run "Implement a data parsing function" --provider google --model gemin
 # With custom working directory
 trae-cli run "Add unit tests for the utils module" --working-dir /path/to/project
 
-# Save trajectory for debugging
-trae-cli run "Refactor the database module" --trajectory-file debug_session.json
+# Save trajectory to a custom path
+trae-cli run "Refactor the database module" --trajectory-path my_trajectories/refactor_run
 
 # Force to generate patches
 trae-cli run "Update the API endpoints" --must-patch
@@ -208,12 +208,15 @@ For detailed information about all available tools and their capabilities, see [
 
 ## 📊 Trajectory Recording
 
-Trae Agent automatically records detailed execution trajectories for debugging and analysis:
+Trae Agent automatically records detailed execution trajectories into a structured directory for debugging and analysis.
+
+#### Default Behavior
+By default, each run creates a unique, organized directory path.
 
 ```bash
 # Auto-generated trajectory file
 trae-cli run "Debug the authentication module"
-# Saves to: trajectories/trajectory_20250612_220546.json
+# Saves to trajectories/anthropic/20250712/113000_a1b2c3d4/
 
 # Custom trajectory file
 trae-cli run "Optimize the database queries" --trajectory-file optimization_debug.json

--- a/docs/TRAJECTORY_RECORDING.md
+++ b/docs/TRAJECTORY_RECORDING.md
@@ -1,6 +1,6 @@
 # Trajectory Recording Functionality
 
-This document describes the trajectory recording functionality added to the Trae Agent project. The system captures detailed information about LLM interactions and agent execution steps for analysis, debugging, and auditing purposes.
+This document describes the trajectory recording functionality added to the Trae Agent project. The system captures detailed information about LLM interactions and agent execution steps for analysis, debugging, and auditing purposes. All data is saved into a structured directory path.
 
 ## Overview
 
@@ -148,18 +148,20 @@ if self.trajectory_recorder:
 
 ### CLI Usage
 
-#### Basic Recording (Auto-generated filename)
+#### Basic Recording (Auto-generated path)
+When you run the agent, it will automatically create a unique, organized directory for the trajectory.
 
 ```bash
-trae run "Create a hello world Python script"
-# Trajectory saved to: trajectories/trajectory_20250612_220546.json
+trae-cli run "Create a hello world Python script" --provider anthropic
+# Trajectory saved to directory: trajectories/anthropic/20250712/103000_a1b2c3d4/
 ```
 
 #### Custom Filename
+You can specify a custom directory for the trajectory output.
 
 ```bash
-trae run "Fix the bug in main.py" --trajectory-file my_debug_session.json
-# Trajectory saved to: my_debug_session.json
+trae-cli run "Fix the bug in main.py" --trajectory-path my_trajectories/debug_session_01
+# Trajectory saved to directory: my_trajectories/debug_session_01/
 ```
 
 #### Interactive Mode
@@ -179,19 +181,40 @@ from trae_agent.utils.config import ModelParameters
 agent = TraeAgent(LLMProvider.ANTHROPIC, model_parameters, max_steps=10)
 
 # Set up trajectory recording
-trajectory_path = agent.setup_trajectory_recording("my_trajectory.json")
+trajectory_path = agent.setup_trajectory_recording("my_custom_trajectories/task1")
 
 # Configure and run task
 agent.new_task("My task", task_args)
 execution = await agent.execute_task()
 
 # Trajectory is automatically saved
-print(f"Trajectory saved to: {trajectory_path}")
+print(f"Trajectory saved to: {trajectory_dir_path}")
 ```
 
-## Trajectory File Format
+## Trajectory Output Structure
 
-The trajectory file is a JSON document with the following structure:
+Each agent run generates a unique directory containing the full context and results of the task. The directory structure is designed for easy browsing and analysis.
+
+### Directory Structure
+
+The path to each trajectory is organized by provider and date, with a unique identifier for each run:
+`trajectories/<provider>/<YYYYMMDD>/<HHMMSS_uuid>/`
+
+A typical output directory contains the following files:
+
+```
+.
+└── trajectories/
+    └── anthropic/
+        └── 20250712/
+            └── 103000_a1b2c3d4/
+                ├── prompt.txt         <-- The raw initial prompt for the task
+                └── trajectory.json    <-- The detailed JSON log of the entire run
+```
+
+### Trajectory JSON Format
+
+The `trajectory.json` file is a document with the following structure:
 
 ```json
 {
@@ -317,11 +340,11 @@ The trajectory file is a JSON document with the following structure:
 
 ## File Management
 
-- Trajectory files are saved in the current working directory by default
-- Files use timestamp-based naming if no custom path is provided
-- Files are automatically created/overwritten
-- The system handles directory creation if needed
-- Files are saved continuously during execution (not just at the end)
+- Each run is saved in its own unique directory to prevent collisions and keep all related artifacts together.
+- By default, all trajectories are stored within a top-level `trajectories/` directory in the current working path.
+- Trajectory directories are automatically named and organized using the pattern: `trajectories/<provider>/<date>/<timestamp_uuid>`.
+- Each directory contains the full `trajectory.json` log and the initial `prompt.txt`.
+- Trajectory data is saved continuously during agent execution to ensure no data is lost if the process is interrupted.
 
 ## Security Considerations
 

--- a/trae_agent/utils/trajectory_recorder.py
+++ b/trae_agent/utils/trajectory_recorder.py
@@ -59,12 +59,12 @@ class TrajectoryRecorder:
             self.trajectory_dir = Path(self._custom_trajectory_path)
         else:
             now = self._start_time
-            date_str = now.strftime("%Y%m%d")
-            timestamp = now.strftime("%H%M%S")
-            short_uuid = str(uuid.uuid4())[:8]
-            unique_folder_name = f"{timestamp}_{short_uuid}"
+            _date_str = now.strftime("%Y%m%d")
+            _timestamp = now.strftime("%H%M%S")
+            _short_uuid = str(uuid.uuid4())[:8]
+            _unique_folder_name = f"{_timestamp}_{_short_uuid}"
 
-            self.trajectory_dir = Path("trajectories") / provider / date_str / unique_folder_name
+            self.trajectory_dir = Path("trajectories") / provider / _date_str / _unique_folder_name
 
         self.trajectory_path = self.trajectory_dir / "trajectory.json"
         self.trajectory_data.update(


### PR DESCRIPTION
This PR introduces a fix for #150 and adds additional feature for trajectory paths handling. With these changes, the cli can handle long prompts exceeding 260 characters. Also, trajectories are now saved in a structured, hierarchical path: `trajectories/<provider>/<YYYYMMDD>/<HHMMSS_uuid>`. This makes it easy to browse and filter runs by provider and date.

```
.
└── google
    └── 20250712
        ├── 011028_0b2c9c3f
        │   ├── prompt.txt
        │   └── trajectory.json
        └── 011058_81c72940
            ├── prompt.txt
            └── trajectory.json

5 directories, 4 files
```