### PR TITLE
fix: add missing socksio dependency for SOCKS proxy support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "rich>=13.0.0",
     "typing-extensions>=4.0.0",
     "ollama>=0.5.1",
+    "socksio>=1.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
fix: add missing socksio dependency for SOCKS proxy support

Resolves ImportError on macOS when using SOCKS proxy with httpx. Users can now run `uv sync --all-extras` to install all dependencies.

## Description
Added `socksio` as a project dependency to fix ImportError that occurs when the application attempts to use SOCKS proxy functionality through httpx transport layer. This dependency was missing from the project configuration, causing the anthropic client initialization to fail on macOS systems.

## More Information
The error was occurring in the httpx transport initialization when creating an Anthropic client with SOCKS proxy settings. The `socksio` package is required by httpx for SOCKS proxy support, but it's an optional dependency that wasn't included in our project's dependency list.

Changes made:
- Added `socksio` to project dependencies in `pyproject.toml` using `uv add socksio`
- Updated lock file to include the new dependency
- Ensures consistent dependency installation across all development environments

This fix ensures that all users, regardless of their platform, will have the required dependencies when running `uv sync --all-extras`.

## Validation
1. Clone the repository
2. Run `uv sync --all-extras` to install all dependencies
3. Configure SOCKS proxy settings
4. Run the application - it should no longer throw ImportError for missing socksio package
5. Verify that SOCKS proxy functionality works correctly

## Linked Issues
<!-- Add issue number if this relates to a specific GitHub issue -->




<img width="2002" height="1200" alt="image" src="https://github.com/user-attachments/assets/4cf261bd-6b3d-4f46-a566-81ec52537e21" />
