### PR TITLE
fix(cli): handles long prompt error and explicit --file flag with tests for cli.

### DIFF
--- a/evaluation/swebench.py
+++ b/evaluation/swebench.py
@@ -273,7 +273,7 @@ class SWEBenchEvaluation:
         problem_statement_path = instance_dir + "/problem_statement.txt"
         patch_file_path = instance_dir + f"/{instance['instance_id']}.patch"
         traj_path = instance_dir + f"/{instance['instance_id']}.json"
-        command = f'source trae-agent/.venv/bin/activate && trae-cli run {problem_statement_path} --working-dir="/testbed/" --config-file trae_config_local.json --max-steps 200 --must-patch --patch-path {patch_file_path} --trajectory-file {traj_path}'
+        command = f'source trae-agent/.venv/bin/activate && trae-cli run --file {problem_statement_path} --working-dir="/testbed/" --config-file trae_config_local.json --max-steps 200 --must-patch --patch-path {patch_file_path} --trajectory-file {traj_path}'
         new_command = f"/bin/bash -c '{command}'"
 
         try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,96 @@
+import unittest
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from trae_agent.cli import cli
+
+
+class TestCli(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+
+    @patch("trae_agent.cli.create_agent")
+    @patch("trae_agent.cli.asyncio.run")
+    def test_run_with_long_prompt(self, mock_asyncio_run, mock_create_agent):
+        """Test that a long prompt string is handled correctly."""
+        long_prompt = "a" * 500  # A string longer than typical filename limits
+        result = self.runner.invoke(cli, ["run", long_prompt])
+        self.assertEqual(result.exit_code, 0)
+        mock_create_agent.return_value.new_task.assert_called_once()
+        call_args, _ = mock_create_agent.return_value.new_task.call_args
+        self.assertEqual(call_args[0], long_prompt)
+
+    @patch("trae_agent.cli.create_agent")
+    @patch("trae_agent.cli.asyncio.run")
+    def test_run_with_file_argument(self, mock_asyncio_run, mock_create_agent):
+        """Test that the --file argument correctly reads from a file."""
+        with self.runner.isolated_filesystem():
+            with open("task.txt", "w") as f:
+                f.write("task from file")
+
+            result = self.runner.invoke(cli, ["run", "--file", "task.txt"])
+            self.assertEqual(result.exit_code, 0)
+            mock_create_agent.return_value.new_task.assert_called_once()
+            call_args, _ = mock_create_agent.return_value.new_task.call_args
+            self.assertEqual(call_args[0], "task from file")
+
+    def test_run_with_nonexistent_file(self):
+        """Test for a clear error when --file points to a non-existent file."""
+        result = self.runner.invoke(cli, ["run", "--file", "nonexistent.txt"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Error: File not found: nonexistent.txt", result.output)
+
+    def test_run_with_both_task_and_file(self):
+        """Test for a clear error when both task string and --file are used."""
+        result = self.runner.invoke(cli, ["run", "some task", "--file", "task.txt"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn(
+            "Error: Cannot use both a task string and the --file argument.", result.output
+        )
+
+    def test_run_with_no_input(self):
+        """Test for a clear error when neither task string nor --file is provided."""
+        result = self.runner.invoke(cli, ["run"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn(
+            "Error: Must provide either a task string or use the --file argument.", result.output
+        )
+
+    def test_run_with_nonexistent_working_dir(self):
+        """Test for a clear error when --working-dir points to a non-existent directory."""
+        result = self.runner.invoke(
+            cli, ["run", "some task", "--working-dir", "/path/to/nonexistent/dir"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Error changing directory", result.output)
+
+    @patch("trae_agent.cli.create_agent")
+    @patch("trae_agent.cli.asyncio.run")
+    def test_run_with_string_that_is_also_a_filename(self, mock_asyncio_run, mock_create_agent):
+        """Test that a task string that looks like a file is treated as a string."""
+        with self.runner.isolated_filesystem():
+            with open("task.txt", "w") as f:
+                f.write("file content")
+
+            result = self.runner.invoke(cli, ["run", "task.txt"])
+            self.assertEqual(result.exit_code, 0)
+
+            mock_create_agent.return_value.new_task.assert_called_once()
+            call_args, _ = mock_create_agent.return_value.new_task.call_args
+            self.assertEqual(call_args[0], "task.txt")
+
+    @patch("trae_agent.cli.create_agent")
+    def test_run_handles_agent_exception(self, mock_create_agent):
+        """Test that the CLI handles exceptions raised from the agent gracefully."""
+        # deliberately make the mock agent's execute_task raise an error
+        mock_agent_instance = mock_create_agent.return_value
+        mock_agent_instance.execute_task.side_effect = Exception("Core agent failed")
+
+        result = self.runner.invoke(cli, ["run", "some task"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Unexpected error: Core agent failed", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trae_agent/cli.py
+++ b/trae_agent/cli.py
@@ -111,14 +111,15 @@ def run(
         sys.exit(1)
 
     # Change working directory if specified
-    if not working_dir:
-        working_dir = os.getcwd()
+    if working_dir:
         try:
             os.chdir(working_dir)
             console.print(f"[blue]Changed working directory to: {working_dir}[/blue]")
         except Exception as e:
             console.print(f"[red]Error changing directory: {e}[/red]")
             sys.exit(1)
+    else:
+        working_dir = os.getcwd()
 
     config = load_config(config_file, provider, model, model_base_url, api_key, max_steps)
 

--- a/trae_agent/cli.py
+++ b/trae_agent/cli.py
@@ -56,7 +56,8 @@ def cli():
 
 
 @cli.command()
-@click.argument("task")
+@click.argument("task", required=False)
+@click.option("--file", "-f", "file_path", help="Path to a file containing the task description.")
 @click.option("--provider", "-p", help="LLM provider to use")
 @click.option("--model", "-m", help="Specific model to use")
 @click.option("--model-base-url", help="Base URL for the model API")
@@ -68,7 +69,8 @@ def cli():
 @click.option("--trajectory-file", "-t", help="Path to save trajectory file")
 @click.option("--patch-path", "-pp", help="Path to patch file")
 def run(
-    task: str,
+    task: str | None,
+    file_path: str | None,
     patch_path: str,
     provider: str | None = None,
     model: str | None = None,
@@ -91,6 +93,23 @@ def run(
         None (it is expected to be ended after calling the run function)
     """
 
+    if file_path:
+        if task:
+            console.print(
+                "[red]Error: Cannot use both a task string and the --file argument.[/red]"
+            )
+            sys.exit(1)
+        try:
+            task = Path(file_path).read_text()
+        except FileNotFoundError:
+            console.print(f"[red]Error: File not found: {file_path}[/red]")
+            sys.exit(1)
+    elif not task:
+        console.print(
+            "[red]Error: Must provide either a task string or use the --file argument.[/red]"
+        )
+        sys.exit(1)
+
     # Change working directory if specified
     if not working_dir:
         working_dir = os.getcwd()
@@ -100,10 +119,6 @@ def run(
         except Exception as e:
             console.print(f"[red]Error changing directory: {e}[/red]")
             sys.exit(1)
-
-    task_path = Path(task)
-    if task_path.exists() and task_path.is_file():
-        task = task_path.read_text()
 
     config = load_config(config_file, provider, model, model_base_url, api_key, max_steps)
 


### PR DESCRIPTION
This PR introduces fix for #150. With these changes,

1) ```trae-cli run "..." ``` will always treat the input as a literal task string, regardless of its length or content.
2) To run a task from a file, the user must now use the new explicit ```--file``` flag: 

```trae-cli run --file /path/to/task.txt.```

The cli is able to handle long prompts now. I have also included 8 tests for ```cli.py``` covering edge cases that I could think of.

```
1) test_run_with_long_prompt
2) test_run_with_file_argument
3) test_run_with_nonexistent_file
4) test_run_with_both_task_and_file
5) test_run_with_no_input
6) test_run_with_nonexistent_working_dir
7) test_run_with_string_that_is_also_a_filename
8) test_run_handles_agent_exception
```