### PR TITLE
Fix: Use correct provider name in retry error logs

### DIFF
--- a/trae_agent/utils/openai_client.py
+++ b/trae_agent/utils/openai_client.py
@@ -87,6 +87,7 @@ class OpenAIClient(BaseLLMClient):
         retry_decorator = retry_with(
             func=self._create_openai_response,
             max_retries=model_parameters.max_retries,
+            provider_name="openai"
         )
         response = retry_decorator(api_call_input, model_parameters, tool_schemas)
 

--- a/trae_agent/utils/openai_client.py
+++ b/trae_agent/utils/openai_client.py
@@ -87,7 +87,7 @@ class OpenAIClient(BaseLLMClient):
         retry_decorator = retry_with(
             func=self._create_openai_response,
             max_retries=model_parameters.max_retries,
-            provider_name="openai"
+            provider_name="openai",
         )
         response = retry_decorator(api_call_input, model_parameters, tool_schemas)
 

--- a/trae_agent/utils/openrouter_client.py
+++ b/trae_agent/utils/openrouter_client.py
@@ -108,6 +108,7 @@ class OpenRouterClient(BaseLLMClient):
         retry_decorator = retry_with(
             func=self._create_openrouter_response,
             max_retries=model_parameters.max_retries,
+            provider_name="openrouter"
         )
         response = retry_decorator(model_parameters, tool_schemas, extra_headers)
 

--- a/trae_agent/utils/openrouter_client.py
+++ b/trae_agent/utils/openrouter_client.py
@@ -108,7 +108,7 @@ class OpenRouterClient(BaseLLMClient):
         retry_decorator = retry_with(
             func=self._create_openrouter_response,
             max_retries=model_parameters.max_retries,
-            provider_name="openrouter"
+            provider_name="openrouter",
         )
         response = retry_decorator(model_parameters, tool_schemas, extra_headers)
 

--- a/trae_agent/utils/retry_utils.py
+++ b/trae_agent/utils/retry_utils.py
@@ -12,7 +12,9 @@ T = TypeVar("T")
 def retry_with(
     func: Callable[..., T],
     max_retries: int = 3,
+    provider_name: str = "unknown",
 ) -> Callable[..., T]:
+
     """
     Decorator that adds retry logic with randomized backoff.
 
@@ -40,9 +42,7 @@ def retry_with(
 
                 sleep_time = random.randint(3, 30)
                 this_error_message = str(e)
-                print(
-                    f"OpenAI API call failed: {this_error_message} will sleep for {sleep_time} seconds and will retry."
-                )
+                print(f"{provider_name.capitalize()} API call failed: {this_error_message} will sleep for {sleep_time} seconds and will retry.")
                 # Randomly sleep for 3-30 seconds
                 time.sleep(sleep_time)
 

--- a/trae_agent/utils/retry_utils.py
+++ b/trae_agent/utils/retry_utils.py
@@ -14,7 +14,6 @@ def retry_with(
     max_retries: int = 3,
     provider_name: str = "unknown",
 ) -> Callable[..., T]:
-
     """
     Decorator that adds retry logic with randomized backoff.
 
@@ -42,7 +41,9 @@ def retry_with(
 
                 sleep_time = random.randint(3, 30)
                 this_error_message = str(e)
-                print(f"{provider_name.capitalize()} API call failed: {this_error_message} will sleep for {sleep_time} seconds and will retry.")
+                print(
+                    f"{provider_name.capitalize()} API call failed: {this_error_message} will sleep for {sleep_time} seconds and will retry."
+                )
                 # Randomly sleep for 3-30 seconds
                 time.sleep(sleep_time)
 


### PR DESCRIPTION
## Description

This pull request fixes a misleading error message that always printed `OpenAI API call failed` during retry attempts, even when the actual provider was different (e.g. `openrouter`). The message now dynamically reflects the actual provider being used.

## More Information

# Changes Made

`retry_with` in `retry_utils.py` now accepts a `provider_name` parameter.

The log message inside `retry_with` was updated to use this dynamic value:

```python
print(f"{provider_name.capitalize()} API call failed: {this_error_message} will sleep for {sleep_time} seconds and will retry.")
```
`OpenRouterClient` and `OpenAIClient` were updated to pass the correct `provider_name` when initializing the retry decorator:

```python
retry_decorator = retry_with(
    func=self._create_openrouter_response,
    max_retries=model_parameters.max_retries,
    provider_name="openrouter"
)
```
```python
retry_decorator = retry_with(
    func=self._create_openai_response,
    max_retries=model_parameters.max_retries,
    provider_name="openai"
)
```
# Reasoning
This change was necessary to avoid confusion when debugging or interpreting logs, especially for users of alternate providers like OpenRouter. The previous hardcoded "OpenAI" string was misleading and incorrectly attributed errors.


## Validation

1. Set up a model provider as `openrouter`.
2. Simulate a failed API request (e.g., disconnect network or use invalid credentials).
3. Observe the console/logs.

# Expected output:
```bash
Openrouter API call failed: Request not allowed will sleep for 16 seconds and will retry.
```
Repeat the test for `openai` to ensure log shows:
```bash
Openai API call failed: ...
```
## Linked Issues

Resolves #177 
