### PR TITLE
fix:Organize Makefile and related documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
-.PHONY: uv-venv uv-sync install-dev uv-pre-commit uv-test test pre-commit fix-format pre-commit-install pre-commit-run clean
-=======
-.PHONY: uv-venv uv-sync install-dev uv-pre-commit uv-test test pre-commit pre-commit-install pre-commit-run clean
->>>>>>> edccc07eaa11d9ad97f99ff5fa7f774df6257a31
+.PHONY: help uv-venv uv-sync install-dev uv-pre-commit uv-test test pre-commit fix-format pre-commit-install pre-commit-run clean
 
 # Default target
 help:
@@ -16,10 +12,7 @@ help:
 	@echo "  pre-commit-install- Install pre-commit hooks"
 	@echo "  pre-commit-run    - Run pre-commit hooks on all files"
 	@echo "  pre-commit        - Install and run pre-commit hooks on all files"
-<<<<<<< HEAD
 	@echo "  fix-format        - Fix formatting errors"
-=======
->>>>>>> edccc07eaa11d9ad97f99ff5fa7f774df6257a31
 	@echo "  clean             - Clean up build artifacts and cache"
 
 # Installation commands

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,47 @@
-.PHONY: help install install-test install-dev test test-cov test-watch pre-commit pre-commit-install pre-commit-run lint format type-check clean
+.PHONY: uv-venv uv-sync install-dev uv-pre-commit uv-test test pre-commit fix-format pre-commit-install pre-commit-run clean
 
 # Default target
 help:
 	@echo "Available commands:"
-	@echo "  install         - Install the package in development mode"
-	@echo "  install-test    - Install test dependencies"
-	@echo "  install-dev     - Install all dependencies including test and evaluation"
-	@echo "  test            - Run tests (skips external service tests)"
-	@echo "  pre-commit      - Run pre-commit hooks on all files"
-	@echo "  pre-commit-install - Install pre-commit hooks"
-	@echo "  pre-commit-run  - Run pre-commit hooks on changed files"
-	@echo "  clean           - Clean up build artifacts and cache"
+	@echo "  install-dev        - Create venv and install all dependencies (recommended for development)"
+	@echo "  uv-venv           - Create a Python virtual environment using uv"
+	@echo "  uv-sync           - Install all dependencies (including test/evaluation) using uv"
+	@echo "  uv-test           - Run all tests (via uv, skips some external service tests)"
+	@echo "  test              - Run all tests (skips some external service tests)"
+	@echo "  uv-pre-commit     - Run pre-commit hooks on all files (via uv)"
+	@echo "  pre-commit-install- Install pre-commit hooks"
+	@echo "  pre-commit-run    - Run pre-commit hooks on all files"
+	@echo "  pre-commit        - Install and run pre-commit hooks on all files"
+	@echo "  fix-format        - Fix formatting errors"
+	@echo "  clean             - Clean up build artifacts and cache"
 
 # Installation commands
 uv-venv:
 	uv venv
-
 uv-sync:
 	uv sync --all-extras
+install-dev: uv-venv uv-sync
 
+# Pre-commit commands
 uv-pre-commit:
 	uv run pre-commit run --all-files
 
-uv-test:
-	SKIP_OLLAMA_TEST=true SKIP_OPENROUTER_TEST=true SKIP_GOOGLE_TEST=true uv run pytest tests/ -v --tb=short --continue-on-collection-errors
-
-# Testing commands
-test:
-	SKIP_OLLAMA_TEST=true SKIP_OPENROUTER_TEST=true SKIP_GOOGLE_TEST=true pytest
-
-# Pre-commit commands
-pre-commit: pre-commit-install pre-commit-run
-
 pre-commit-install:
 	pre-commit install
-
 pre-commit-run:
 	pre-commit run --all-files
+pre-commit: pre-commit-install pre-commit-run
+
+# fix formatting error
+fix-format:
+	ruff format .
+	ruff check --fix .
+
+# Testing commands
+uv-test:
+	SKIP_OLLAMA_TEST=true SKIP_OPENROUTER_TEST=true SKIP_GOOGLE_TEST=true uv run pytest tests/ -v --tb=short --continue-on-collection-errors
+test:
+	SKIP_OLLAMA_TEST=true SKIP_OPENROUTER_TEST=true SKIP_GOOGLE_TEST=true pytest
 
 # Clean up
 clean:

--- a/README.md
+++ b/README.md
@@ -232,13 +232,27 @@ For more details, see [docs/TRAJECTORY_RECORDING.md](docs/TRAJECTORY_RECORDING.m
 For detailed contribution guidelines, please refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
 1. Fork the repository
-2. Set up a development install(`make install-dev pre-commit-install`)
+2. Set up a development install:
+   ```bash
+   make install-dev
+   ```
 3. Create a feature branch (`git checkout -b feature/amazing-feature`)
 4. Make your changes
 5. Add tests for new functionality
-6. Commit your changes (`git commit -m 'Add amazing feature'`)
-7. Push to the branch (`git push origin feature/amazing-feature`)
-8. Open a Pull Request
+6. Pre-commit check
+   ```bash
+    make pre-commit
+    or:
+    make uv-pre-commit
+   ```
+    if having formatting error,please try:
+   ```
+    make fix-format
+   ```
+
+7. Commit your changes (`git commit -m 'Add amazing feature'`)
+8. Push to the branch (`git push origin feature/amazing-feature`)
+9. Open a Pull Request
 
 ### Development Guidelines
 


### PR DESCRIPTION
## Description

sync Makefile and README commands for development setup

- Add install-dev target to Makefile for one-step environment setup
- Update README contributing guide to use install-dev command
- Fix pre-commit commands in README to match actual Makefile targets
- Add ruff formatting commands as fallback for formatting errors
- Ensure documentation consistency between Makefile and README

This change simplifies the development setup process by providing
a single command (make install-dev) that creates virtual environment
and installs all dependencies, making it easier for new contributors
to get started with the project.

## More Information


## Validation


## Linked Issues