### PR TITLE
fix[cli] fast-fail when using relative path of --working_dir

### DIFF
--- a/trae_agent/cli.py
+++ b/trae_agent/cli.py
@@ -121,6 +121,13 @@ def run(
     else:
         working_dir = os.getcwd()
 
+    # Ensure working directory is an absolute path
+    if not Path(working_dir).is_absolute():
+        console.print(
+            f"[red]Working directory must be an absolute path: {working_dir}, it should start with `/`[/red]"
+        )
+        sys.exit(1)
+
     config = load_config(config_file, provider, model, model_base_url, api_key, max_steps)
 
     # Create agent


### PR DESCRIPTION
## Description

This pull request addresses a bug where using a relative path for the --working-dir argument causes unpredictable behavior and errors during agent execution.

The agent's tools, particularly edit_tool.py, strictly require absolute paths for file operations. However, the command-line interface did not enforce this requirement for the working directory. This discrepancy caused conflicts between the model's path construction logic and the tool's validation checks, leading to operational failures.

This PR introduces a fast-fail check in the CLI to validate that the provided working-dir is an absolute path, preventing these downstream issues and ensuring system stability.

## More Information

The core issue stems from a conflict between two components:

The Model's Prompting: The model is instructed to build absolute paths using the project root (You MUST construct the full, absolute path by combining the [Project root path] provided in the user's message with the file's path inside the project).
The Tool's Validation: The validate_path function within [edit_tool.py] raises a ToolError if a given path is not absolute.
When a user specifies a relative path like . or ../ as the working-dir, the agent's attempts to create valid, absolute file paths fail, leading to confusing errors and unpredictable behavior, especially in multi-turn conversations.

By adding an explicit check in [cli.py], we ensure the working-dir is a valid absolute path from the start, resolving this conflict and making the agent's file operations more robust and reliable.

## Validation

### wrong output when typing 
```shell
trae-cli run "Create a hello world Python script" --working-dir ./test_aaa
```
the trajectory will be llike : 
[trajectory_20250714_212505.json](https://github.com/user-attachments/files/21217116/trajectory_20250714_212505.json)

### when apply fast-fail
just output **Working directory must be an absolute path: ./test_aaa, it should start with `/`** 



