### PR TITLE
fix(config): support loading API keys and base URLs from environment …

### DIFF
--- a/trae_agent/cli.py
+++ b/trae_agent/cli.py
@@ -287,7 +287,19 @@ def interactive(
 
 @cli.command()
 @click.option("--config-file", help="Path to configuration file", default="trae_config.json")
-def show_config(config_file: str):
+@click.option("--provider", "-p", help="LLM provider to use")
+@click.option("--model", "-m", help="Specific model to use")
+@click.option("--model-base-url", help="Base URL for the model API")
+@click.option("--api-key", "-k", help="API key (or set via environment variable)")
+@click.option("--max-steps", help="Maximum number of execution steps", type=int)
+def show_config(
+    config_file: str,
+    provider: str | None = None,
+    model: str | None = None,
+    model_base_url: str | None = None,
+    api_key: str | None = None,
+    max_steps: int | None = None,
+):
     """Show current configuration settings."""
     config_path = Path(config_file)
     if not config_path.exists():
@@ -301,7 +313,7 @@ Using default settings and environment variables.""",
             )
         )
 
-    config = Config(config_file)
+    config = load_config(config_file, provider, model, model_base_url, api_key, max_steps)
 
     # Display general settings
     general_table = Table(title="General Settings")
@@ -314,21 +326,28 @@ Using default settings and environment variables.""",
     console.print(general_table)
 
     # Display provider settings
-    for provider_name, provider_config in config.model_providers.items():
-        provider_table = Table(title=f"{provider_name.title()} Configuration")
-        provider_table.add_column("Setting", style="cyan")
-        provider_table.add_column("Value", style="green")
+    provider_config = config.model_providers[config.default_provider]
+    provider_table = Table(title=f"{config.default_provider.title()} Configuration")
+    provider_table.add_column("Setting", style="cyan")
+    provider_table.add_column("Value", style="green")
 
-        provider_table.add_row("Model", provider_config.model or "Not set")
-        provider_table.add_row("API Key", "Set" if provider_config.api_key else "Not set")
-        provider_table.add_row("Max Tokens", str(provider_config.max_tokens))
-        provider_table.add_row("Temperature", str(provider_config.temperature))
-        provider_table.add_row("Top P", str(provider_config.top_p))
+    provider_table.add_row("Model", provider_config.model or "Not set")
+    provider_table.add_row("Base URL", provider_config.base_url or "Not set")
+    provider_table.add_row("API Version", provider_config.api_version or "Not set")
+    provider_table.add_row(
+        "API Key",
+        f"Set ({provider_config.api_key[:4]}...{provider_config.api_key[-4:]})"
+        if provider_config.api_key
+        else "Not set",
+    )
+    provider_table.add_row("Max Tokens", str(provider_config.max_tokens))
+    provider_table.add_row("Temperature", str(provider_config.temperature))
+    provider_table.add_row("Top P", str(provider_config.top_p))
 
-        if provider_name == "anthropic":
-            provider_table.add_row("Top K", str(provider_config.top_k))
+    if config.default_provider == "anthropic":
+        provider_table.add_row("Top K", str(provider_config.top_k))
 
-        console.print(provider_table)
+    console.print(provider_table)
 
 
 @cli.command()

--- a/trae_agent/utils/config.py
+++ b/trae_agent/utils/config.py
@@ -92,17 +92,14 @@ class Config:
                 provider_config: dict[str, Any] = self._config.get("model_providers", {}).get(
                     provider, {}
                 )
-		env_api_key = os.getenv(f"{provider.upper()}_API_KEY")
-    		env_base_url = os.getenv(f"{provider.upper()}_BASE_URL")
 
-    		api_key = provider_config.get("api_key") or env_api_key or ""
-    		base_url = provider_config.get("base_url") or env_base_url
-    		
                 candidate_count = provider_config.get("candidate_count")
                 self.model_providers[provider] = ModelParameters(
                     model=str(provider_config.get("model", "")),
-                    api_key=str(api_key),
-		    base_url=str(base_url) if base_url else None,
+                    api_key=str(provider_config.get("api_key", "")),
+                    base_url=str(provider_config.get("base_url"))
+                    if "base_url" in provider_config
+                    else None,
                     max_tokens=int(provider_config.get("max_tokens", 1000)),
                     temperature=float(provider_config.get("temperature", 0.5)),
                     top_p=float(provider_config.get("top_p", 1)),


### PR DESCRIPTION
### Description

This PR enables `trae-agent` to correctly fall back to environment variables such as `OPENAI_API_KEY` and `OPENAI_BASE_URL` when the API key or base URL is not explicitly provided in the CLI arguments or `trae_config.json`.

Previously, `trae-cli show-config` and `trae-cli run` would ignore these environment variables, even when they were properly set (e.g., via `.zprofile`), resulting in errors or empty values in the configuration. This fix ensures a complete and correct config resolution chain: **CLI > ENV > Config file > Default**.

---

### More Information

The fix updates the `Config.__init__()` method to explicitly check for environment variables per provider (`{PROVIDER}_API_KEY`, `{PROVIDER}_BASE_URL`) when `api_key` and `base_url` are missing in the config file.

For example, if you run:
```bash
export OPENAI_API_KEY="test-key"
export OPENAI_BASE_URL="https://api.example.com"
trae-cli show-config
```
You’ll now see the key and URL populated correctly, even if they're not in `trae_config.json`.

---

### Validation

- Export environment variables like `OPENAI_API_KEY` and `OPENAI_BASE_URL`.
- Remove `api_key` and `base_url` from your config file (or delete the config entirely).
- Run `trae-cli show-config` – it should reflect the env var values.
- Run a full command using `--provider openai` and confirm that it no longer crashes.
- Optionally test with another provider like `kimi` or `claude` to confirm provider-specific env vars also resolve correctly.

---

### Linked Issues
Resolves #196 

Let me know if you want to add logging or stricter validation in a follow-up.

