### PR TITLE
fix(ollama): avoid AttributeError by safely handling missing 'type' in tool call responses

### DIFF
--- a/trae_agent/utils/ollama_client.py
+++ b/trae_agent/utils/ollama_client.py
@@ -112,7 +112,7 @@ class OllamaClient(BaseLLMClient):
         tool_calls: list[ToolCall] = []
         if response.message.tool_calls:
             for output_block in response.message.tool_calls:
-                if output_block.type == "function_call":
+                if hasattr(output_block, "name") and hasattr(output_block, "arguments"):
                     tool_calls.append(
                         ToolCall(
                             call_id=output_block.call_id,
@@ -134,10 +134,11 @@ class OllamaClient(BaseLLMClient):
                     if output_block.id:
                         tool_call_param["id"] = output_block.id
                     self.message_history.append(tool_call_param)
-                elif output_block.type == "message":
-                    for content_block in output_block.content:
-                        if content_block.type == "output_text":
-                            content += content_block.text
+                elif hasattr(output_block, "type") and output_block.type == "message":
+                    if hasattr(output_block, "content"):
+                        for content_block in output_block.content:
+                            if hasattr(content_block, "type") and content_block.type == "output_text":
+                                content += content_block.text
 
         if content != "":
             self.message_history.append(

--- a/trae_agent/utils/ollama_client.py
+++ b/trae_agent/utils/ollama_client.py
@@ -137,7 +137,10 @@ class OllamaClient(BaseLLMClient):
                 elif hasattr(output_block, "type") and output_block.type == "message":
                     if hasattr(output_block, "content"):
                         for content_block in output_block.content:
-                            if hasattr(content_block, "type") and content_block.type == "output_text":
+                            if (
+                                hasattr(content_block, "type")
+                                and content_block.type == "output_text"
+                            ):
                                 content += content_block.text
 
         if content != "":


### PR DESCRIPTION
## Description

This pull request fixes a runtime error occurring when using Ollama with tool calls. The bug originated from assuming that every `tool_call` object returned by the Ollama API would contain a `.type` attribute. However, some responses lack this field, causing the following exception:
```bash
AttributeError: 'ToolCall' object has no attribute 'type'
```
The logic has now been updated to safely check the structure of `tool_call` objects using `hasattr(...)` before accessing attributes like `type`, `content`, etc.

## More Information

### Problem Code
```python
for output_block in response.message.tool_calls:
    if output_block.type == "function_call":  # This causes AttributeError if 'type' is missing
```
### Fixed Code
```python
for output_block in response.message.tool_calls:
    if hasattr(output_block, "name") and hasattr(output_block, "arguments"):  # ✅ Safer inference of tool call
        ...
    elif hasattr(output_block, "type") and output_block.type == "message":
        if hasattr(output_block, "content"):
            for content_block in output_block.content:
                if hasattr(content_block, "type") and content_block.type == "output_text":
                    content += content_block.text
```
These changes ensure that only valid tool call or message blocks are processed, preventing runtime crashes while remaining fully compatible with Ollama's varying response formats.

## Validation

To validate this fix:
1. Run an agent using a model via Ollama that supports tool calls (e.g. `llama3.1:latest`)
2. Register a tool for the agent.
3. Trigger a tool call via a prompt.
4. Confirm: No exception is thrown, and the tool is invoked correctly.
5. Check that assistant responses and tool call responses are appended to the message history as expected.

## Linked Issues

Resolves #207