### PR TITLE
fix(test): ollama client error api_key

### DIFF
--- a/tests/utils/test_ollama_client_utils.py
+++ b/tests/utils/test_ollama_client_utils.py
@@ -32,7 +32,7 @@ class TestOllamaClient(unittest.TestCase):
         """
         model_parameters = ModelParameters(
             TEST_MODEL,
-            "api-key",
+            "ollama",
             1000,
             0.8,
             7.0,


### PR DESCRIPTION
## Description

<!-- Add a brief description about this pull request including what it does, why it is needed, and other important information for the reviewers -->
In `test_OllamaClient_init` test case, the api key of ollama client is wrong. It is initialized with `api-key`, but asserted as `ollama`.

## More Information

<!-- Add more in-depth information about this pull request, such as the changes made, the reasoning behind them, and any potential impacts. -->

I updated the initial value to `ollama` to match the other test cases.

## Validation

<!-- Introduce how to test this pull request. -->
The overall cases of ollama are skipped. So you should checkout the pr in your computer  with ollama running and `SKIP_OLLAMA_TEST` set as false.

## Linked Issues

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
I don't commit any issue for the bug.
