### PR TITLE
Shell command hangs with long-running tasks

### DIFF
--- a/trae_agent/tools/bash_tool.py
+++ b/trae_agent/tools/bash_tool.py
@@ -112,7 +112,13 @@ class _BashSession:
                     await asyncio.sleep(self._output_delay)
                     # if we read directly from stdout/stderr, it will wait forever for
                     # EOF. use the StreamReader buffer directly instead.
-                    output: str = self._process.stdout._buffer.decode()  # type: ignore[attr-defined] # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType, reportUnknownVariableType]
+                    # output: str = self._process.stdout._buffer.decode()  # type: ignore[attr-defined] # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType, reportUnknownVariableType]
+                    line = await self._process.stdout.readline()
+                    if not line:
+                        continue  # 没有新输出，继续等待
+
+                    decoded = line.decode(errors="ignore")
+                    output += decoded  # 手动拼接 output 缓冲
                     if sentinel_before in output:
                         # strip the sentinel from output
                         output, pivot, exit_banner = output.rpartition(sentinel_before)


### PR DESCRIPTION
## Description

Summary

This change ensures that long-running shell commands (such as programs that produce infrequent or delayed standard output) do not cause the tool to hang indefinitely while waiting for output.

## More Information

Replaced direct access to self._process.stdout._buffer.decode() with await self._process.stdout.readline() for safe incremental reading.

Accumulates stdout content line by line into a local output buffer.

Retains the original sentinel-based error_code detection mechanism (,,,,bash-command-exit-__ERROR_CODE__-banner,,,,).

Maintains compatibility with both Unix-like and Windows shells.

Preserves stderr reading and timeout handling.

## Validation

<!-- Introduce how to test this pull request. -->

## Linked Issues

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
