### PR TITLE
Fix empty content error in tool call result handling for Anthropic API

### DIFF
--- a/trae_agent/utils/llm_clients/anthropic_client.py
+++ b/trae_agent/utils/llm_clients/anthropic_client.py
@@ -208,6 +208,10 @@ class AnthropicClient(BaseLLMClient):
             result += tool_call_result.error
         result = result.strip()
 
+        # Provide a default error message if the tool failed but didn't provide details
+        if not tool_call_result.success and not result:
+            result = "Tool execution failed without providing error details."
+
         return anthropic.types.ToolResultBlockParam(
             tool_use_id=tool_call_result.call_id,
             type="tool_result",


### PR DESCRIPTION
## Description

This pull request addresses an issue with the Anthropic API where an empty content field in the tool call result would cause a `400 Bad Request` error when `is_error` is true. 

- Added a default error message to the tool call result to ensure compliance with the API requirements.

## More Information
The exact message the API returns:
`{
  "type": "error",
  "error": {
    "type": "invalid_request_error",
    "message": "messages.52.content.0.tool_result: content cannot be empty if is_error is true"
  }
}
`

## Validation

1. Trigger a tool call that is expected to fail (e.g., by providing invalid parameters or data) and doesn't return the response content (maybe a custom tool).
2. Ensure that the `content` field is populated with a default error message when the tool fails.

## Linked Issues
- Closes #230

