### PR TITLE
Add MCP-support feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ target/
 profile_default/
 ipython_config.py
 
+# Node stuff:
+.node_modules/
+
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ We recommend to configure Trae Agent using the config file.
    - Replace `"your_azure_base_url"` with your actual Azure base URL
    - Replace other placeholder URLs and API keys as needed
 
+3. **(Optional) Add mcp_servers section to enable agent to call MCP services:**
+   You can configure MCP services by adding an mcp_servers section in trae_config.json.
+   Here's an example configuration for integrating Playwright MCP:
+
+   ``` json
+      {
+         "default_provider": "anthropic",
+         "max_steps": 20,
+         "enable_lakeview": true,
+         "mcp_servers": {
+            "playwright": {
+               "command": "npx",
+               "args": [
+               "@playwright/mcp@0.0.27"
+               ]
+            }
+         }
+      }
+   ```
 **Note:** The `trae_config.json` file is ignored by git to prevent accidentally committing your API keys.
 
 You can also set your API keys as environment variables:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "trae-agent",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@playwright/test": "^1.54.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@playwright/test": "^1.54.2"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "tree-sitter-languages==1.10.2",
     "tree-sitter==0.21.3",
     "ruff>=0.12.4",
+    "mcp==1.12.2",
+    "asyncclick>=8.0.0",
     "pyyaml>=6.0.2",
 ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,21 +1,21 @@
 import unittest
 from unittest.mock import patch
 
-from click.testing import CliRunner
+from asyncclick.testing import CliRunner
 
 from trae_agent.cli import cli
 
 
-class TestCli(unittest.TestCase):
+class TestCli(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.runner = CliRunner()
 
     @patch("trae_agent.cli.create_agent")
     @patch("trae_agent.cli.asyncio.run")
-    def test_run_with_long_prompt(self, mock_asyncio_run, mock_create_agent):
+    async def test_run_with_long_prompt(self, mock_asyncio_run, mock_create_agent):
         """Test that a long prompt string is handled correctly."""
         long_prompt = "a" * 500  # A string longer than typical filename limits
-        result = self.runner.invoke(cli, ["run", long_prompt])
+        result = await self.runner.invoke(cli, ["run", long_prompt])
         self.assertEqual(result.exit_code, 0)
         mock_create_agent.return_value.new_task.assert_called_once()
         call_args, _ = mock_create_agent.return_value.new_task.call_args
@@ -23,43 +23,43 @@ class TestCli(unittest.TestCase):
 
     @patch("trae_agent.cli.create_agent")
     @patch("trae_agent.cli.asyncio.run")
-    def test_run_with_file_argument(self, mock_asyncio_run, mock_create_agent):
+    async def test_run_with_file_argument(self, mock_asyncio_run, mock_create_agent):
         """Test that the --file argument correctly reads from a file."""
         with self.runner.isolated_filesystem():
             with open("task.txt", "w") as f:
                 f.write("task from file")
 
-            result = self.runner.invoke(cli, ["run", "--file", "task.txt"])
+            result = await self.runner.invoke(cli, ["run", "--file", "task.txt"])
             self.assertEqual(result.exit_code, 0)
             mock_create_agent.return_value.new_task.assert_called_once()
             call_args, _ = mock_create_agent.return_value.new_task.call_args
             self.assertEqual(call_args[0], "task from file")
 
-    def test_run_with_nonexistent_file(self):
+    async def test_run_with_nonexistent_file(self):
         """Test for a clear error when --file points to a non-existent file."""
-        result = self.runner.invoke(cli, ["run", "--file", "nonexistent.txt"])
+        result = await self.runner.invoke(cli, ["run", "--file", "nonexistent.txt"])
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("Error: File not found: nonexistent.txt", result.output)
 
-    def test_run_with_both_task_and_file(self):
+    async def test_run_with_both_task_and_file(self):
         """Test for a clear error when both task string and --file are used."""
-        result = self.runner.invoke(cli, ["run", "some task", "--file", "task.txt"])
+        result = await self.runner.invoke(cli, ["run", "some task", "--file", "task.txt"])
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn(
             "Error: Cannot use both a task string and the --file argument.", result.output
         )
 
-    def test_run_with_no_input(self):
+    async def test_run_with_no_input(self):
         """Test for a clear error when neither task string nor --file is provided."""
-        result = self.runner.invoke(cli, ["run"])
+        result = await self.runner.invoke(cli, ["run"])
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn(
             "Error: Must provide either a task string or use the --file argument.", result.output
         )
 
-    def test_run_with_nonexistent_working_dir(self):
+    async def test_run_with_nonexistent_working_dir(self):
         """Test for a clear error when --working-dir points to a non-existent directory."""
-        result = self.runner.invoke(
+        result = await self.runner.invoke(
             cli, ["run", "some task", "--working-dir", "/path/to/nonexistent/dir"]
         )
         self.assertNotEqual(result.exit_code, 0)
@@ -67,13 +67,15 @@ class TestCli(unittest.TestCase):
 
     @patch("trae_agent.cli.create_agent")
     @patch("trae_agent.cli.asyncio.run")
-    def test_run_with_string_that_is_also_a_filename(self, mock_asyncio_run, mock_create_agent):
+    async def test_run_with_string_that_is_also_a_filename(
+        self, mock_asyncio_run, mock_create_agent
+    ):
         """Test that a task string that looks like a file is treated as a string."""
         with self.runner.isolated_filesystem():
             with open("task.txt", "w") as f:
                 f.write("file content")
 
-            result = self.runner.invoke(cli, ["run", "task.txt"])
+            result = await self.runner.invoke(cli, ["run", "task.txt"])
             self.assertEqual(result.exit_code, 0)
 
             mock_create_agent.return_value.new_task.assert_called_once()

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -1,0 +1,76 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from trae_agent.tools.base import ToolCallArguments, ToolExecResult
+from trae_agent.tools.mcp_tool import MCPTool
+
+
+class TestMCPTool(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        # simulate a tool schema
+        self.mock_tool = MagicMock()
+        self.mock_tool.name = "test_tool"
+        self.mock_tool.description = "A test tool"
+        self.mock_tool.inputSchema = {
+            "required": ["param1"],
+            "properties": {
+                "param1": {"type": "string", "description": "First parameter"},
+                "param2": {"type": "integer", "description": "Second parameter"},
+            },
+        }
+
+        # simulate client side
+        self.mock_client = MagicMock()
+        self.tool = MCPTool(self.mock_client, self.mock_tool, model_provider="test_provider")
+
+    def test_get_name(self):
+        self.assertEqual(self.tool.get_name(), "test_tool")
+
+    def test_get_description(self):
+        self.assertEqual(self.tool.get_description(), "A test tool")
+
+    def test_get_model_provider(self):
+        self.assertEqual(self.tool.get_model_provider(), "test_provider")
+
+    def test_get_parameters(self):
+        params = self.tool.get_parameters()
+        self.assertEqual(len(params), 2)
+        self.assertTrue(any(p.name == "param1" and p.required for p in params))
+        self.assertTrue(any(p.name == "param2" and not p.required for p in params))
+
+    async def test_execute_success(self):
+        mock_response = MagicMock()
+        mock_response.isError = False
+        mock_response.content = [MagicMock(text="Execution successful")]
+        self.mock_client.call_tool = AsyncMock(return_value=mock_response)
+
+        arguments = ToolCallArguments(arguments={"param1": "value", "param2": 123})
+        result: ToolExecResult = await self.tool.execute(arguments)
+
+        self.assertIsNone(result.error)
+        self.assertEqual(result.output, "Execution successful")
+
+    async def test_execute_failure(self):
+        mock_response = MagicMock()
+        mock_response.isError = True
+        mock_response.content = [MagicMock(text="Something went wrong")]
+        self.mock_client.call_tool = AsyncMock(return_value=mock_response)
+
+        arguments = ToolCallArguments(arguments={"param1": "value"})
+        result: ToolExecResult = await self.tool.execute(arguments)
+
+        self.assertIsNone(result.output)
+        self.assertEqual(result.error, "Something went wrong")
+
+    async def test_execute_exception(self):
+        self.mock_client.call_tool = AsyncMock(side_effect=RuntimeError("Tool crashed"))
+
+        arguments = ToolCallArguments(arguments={"param1": "value"})
+        result: ToolExecResult = await self.tool.execute(arguments)
+
+        self.assertIn("Error running mcp tool", result.error)
+        self.assertEqual(result.error_code, -1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils/test_mcp_client.py
+++ b/tests/utils/test_mcp_client.py
@@ -1,0 +1,98 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from trae_agent.utils.mcp_client import MCPClient, MCPServerConfig, MCPServerStatus
+
+
+class TestMCPClient(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.client = MCPClient()
+
+    def test_get_default_server_status(self):
+        status = self.client.get_mcp_server_status("unknown_server")
+        self.assertEqual(status, MCPServerStatus.DISCONNECTED)
+
+    def test_update_and_get_server_status(self):
+        self.client.update_mcp_server_status("test_server", MCPServerStatus.CONNECTED)
+        status = self.client.get_mcp_server_status("test_server")
+        self.assertEqual(status, MCPServerStatus.CONNECTED)
+
+    @patch("trae_agent.utils.mcp_client.ClientSession")
+    async def test_connect_to_server(self, mock_client_session):
+        mock_transport = (MagicMock(), MagicMock())
+
+        mock_instance = mock_client_session.return_value
+
+        mock_instance.initialize = AsyncMock()
+
+        await self.client.connect_to_server("test_server", mock_transport)
+
+        self.assertEqual(
+            self.client.get_mcp_server_status("test_server"), MCPServerStatus.CONNECTED
+        )
+        # mock_instance.initialize.assert_awaited()
+
+    @patch("trae_agent.utils.mcp_client.stdio_client")
+    @patch("trae_agent.utils.mcp_client.ClientSession")
+    async def test_connect_and_discover_stdio(self, mock_client_session, mock_stdio_client):
+        # Setup mock MCP config
+        config = MCPServerConfig(command="echo", args=[], env={}, cwd=".")
+
+        # Mock the returned transport
+        mock_stdio = AsyncMock()
+        mock_writer = AsyncMock()
+        mock_stdio_client.return_value.__aenter__.return_value = (mock_stdio, mock_writer)
+
+        # Mock session and list_tools return
+        mock_session = mock_client_session.return_value
+        mock_session.initialize = AsyncMock()
+
+        mock_session.call_tool = AsyncMock()
+
+        mcp_servers_dict = {}
+        await self.client.connect_and_discover(
+            "test_server", config, mcp_servers_dict, model_provider="mock_provider"
+        )
+        all_tools = []
+        for _, tools in mcp_servers_dict.items():
+            all_tools.extend(tools)
+        self.assertTrue(all(tool.__class__.__name__ == "MCPTool" for tool in all_tools))
+
+    async def test_connect_and_discover_invalid_config(self):
+        config = MCPServerConfig()
+        mcp_servers_dict = {}
+        with self.assertRaises(ValueError):
+            await self.client.connect_and_discover(
+                "invalid_server", config, mcp_servers_dict, model_provider=None
+            )
+        self.assertEqual(len(mcp_servers_dict), 0)
+
+    async def test_call_tool(self):
+        mock_session = AsyncMock()
+        mock_session.call_tool = AsyncMock(return_value={"result": "ok"})
+        self.client.session = mock_session
+
+        result = await self.client.call_tool("tool_name", {"arg1": "val"})
+        self.assertEqual(result, {"result": "ok"})
+
+    async def test_list_tools(self):
+        mock_session = AsyncMock()
+        mock_session.list_tools = AsyncMock(return_value=["tool1", "tool2"])
+        self.client.session = mock_session
+
+        result = await self.client.list_tools()
+        self.assertEqual(result, ["tool1", "tool2"])
+
+    async def test_cleanup(self):
+        self.client.update_mcp_server_status("test_server", MCPServerStatus.CONNECTED)
+        self.client.exit_stack.aclose = AsyncMock()
+
+        await self.client.cleanup("test_server")
+        self.assertEqual(
+            self.client.get_mcp_server_status("test_server"), MCPServerStatus.DISCONNECTED
+        )
+        self.client.exit_stack.aclose.assert_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trae_agent/cli.py
+++ b/trae_agent/cli.py
@@ -9,7 +9,7 @@ import sys
 import traceback
 from pathlib import Path
 
-import click
+import asyncclick as click
 from dotenv import load_dotenv
 from rich.console import Console
 from rich.panel import Panel
@@ -25,7 +25,7 @@ _ = load_dotenv()
 console = Console()
 
 
-def create_agent(trae_agent_config: TraeAgentConfig) -> TraeAgent:
+async def create_agent(trae_agent_config: TraeAgentConfig) -> TraeAgent:
     """
     create_agent creates a Trae Agent with the specified configuration.
     Args:
@@ -35,7 +35,8 @@ def create_agent(trae_agent_config: TraeAgentConfig) -> TraeAgent:
     """
     try:
         # Create agent
-        agent = TraeAgent(trae_agent_config)
+        # agent = TraeAgent(trae_agent_config)
+        agent = await TraeAgent.create(trae_agent_config)
         return agent
 
     except Exception as e:
@@ -64,7 +65,7 @@ def cli():
 @click.option("--config-file", help="Path to configuration file", default="trae_config.json")
 @click.option("--trajectory-file", "-t", help="Path to save trajectory file")
 @click.option("--patch-path", "-pp", help="Path to patch file")
-def run(
+async def run(
     task: str | None,
     file_path: str | None,
     patch_path: str,
@@ -119,7 +120,7 @@ def run(
     trae_agent_config = config.trae_agent
     # Create agent
     if trae_agent_config:
-        agent: TraeAgent = create_agent(trae_agent_config)
+        agent: TraeAgent = await create_agent(trae_agent_config)
     else:
         console.print("[red]Error: trae_agent configuration is required in the config file.[/red]")
         sys.exit(1)
@@ -170,7 +171,8 @@ def run(
             "patch_path": patch_path,
         }
         agent.new_task(task, task_args)
-        _ = asyncio.run(agent.execute_task())
+        # _ = asyncio.run(agent.execute_task())
+        await agent.execute_task()
 
         console.print(f"\n[green]Trajectory saved to: {trajectory_path}[/green]")
 
@@ -195,7 +197,7 @@ def run(
 @click.option("--config-file", help="Path to configuration file", default="trae_config.json")
 @click.option("--max-steps", help="Maximum number of execution steps", type=int, default=20)
 @click.option("--trajectory-file", "-t", help="Path to save trajectory file")
-def interactive(
+async def interactive(
     provider: str | None = None,
     model: str | None = None,
     model_base_url: str | None = None,
@@ -238,7 +240,7 @@ def interactive(
     )
 
     # Create agent
-    agent = create_agent(trae_agent_config)
+    agent = await create_agent(trae_agent_config)
 
     while True:
         try:
@@ -416,7 +418,7 @@ def tools():
 
 def main():
     """Main entry point for the CLI."""
-    cli()
+    asyncio.run(cli())
 
 
 if __name__ == "__main__":

--- a/trae_agent/tools/mcp_tool.py
+++ b/trae_agent/tools/mcp_tool.py
@@ -1,0 +1,58 @@
+from typing import override
+
+import mcp
+
+from .base import Tool, ToolCallArguments, ToolExecResult, ToolParameter
+
+
+class MCPTool(Tool):
+    def __init__(self, client, tool: mcp.types.Tool, model_provider: str | None = None):
+        super().__init__(model_provider)
+        self.client = client
+        self.tool = tool
+
+    @override
+    def get_model_provider(self) -> str | None:
+        return self._model_provider
+
+    @override
+    def get_name(self) -> str:
+        return self.tool.name
+
+    @override
+    def get_description(self) -> str:
+        return self.tool.description
+
+    @override
+    def get_parameters(self) -> list[ToolParameter]:
+        # For OpenAI models, all parameters must be required=True
+        # For other providers, optional parameters can have required=False
+        def properties_to_parameter():
+            parameters = []
+            inputSchema = self.tool.inputSchema
+            required = inputSchema.get("required", [])
+            properties = inputSchema.get("properties", {})
+            for name, prop in properties.items():
+                tool_para = ToolParameter(
+                    name=name,
+                    type=prop["type"],
+                    items=prop.get("items", None),
+                    description=prop["description"],
+                    required=name in required,
+                )
+                parameters.append(tool_para)
+            return parameters
+
+        return properties_to_parameter()
+
+    @override
+    async def execute(self, arguments: ToolCallArguments) -> ToolExecResult:
+        try:
+            output = await self.client.call_tool(self.get_name(), arguments)
+            if output.isError:
+                return ToolExecResult(output=None, error=output.content[0].text)
+            else:
+                return ToolExecResult(output=output.content[0].text)
+
+        except Exception as e:
+            return ToolExecResult(error=f"Error running mcp tool: {e}", error_code=-1)

--- a/trae_agent/utils/legacy_config.py
+++ b/trae_agent/utils/legacy_config.py
@@ -9,7 +9,7 @@
 # pyright: reportUnknownVariableType=false
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, override
 
@@ -42,14 +42,42 @@ class LakeviewConfig:
 
 
 @dataclass
+class MCPServerConfig:
+    # For stdio transport
+    command: str | None = None
+    args: list[str] | None = None
+    env: dict[str, str] | None = None
+    cwd: str | None = None
+
+    # For sse transport
+    url: str | None = None
+
+    # For streamable http transport
+    http_url: str | None = None
+    headers: dict[str, str] | None = None
+
+    # For websocket transport
+    tcp: str | None = None
+
+    # Common
+    timeout: int | None = None
+    trust: bool | None = None
+
+    # Metadata
+    description: str | None = None
+
+
+@dataclass
 class LegacyConfig:
     """Configuration manager for Trae Agent."""
 
     default_provider: str
     max_steps: int
     model_providers: dict[str, ModelParameters]
+    mcp_servers: dict[str, MCPServerConfig]
     lakeview_config: LakeviewConfig | None = None
     enable_lakeview: bool = True
+    allow_mcp_servers: list[str] = field(default_factory=list)
 
     def __init__(self, config_or_config_file: str | dict = "trae_config.json"):  # pyright: ignore[reportMissingTypeArgument, reportUnknownParameterType]
         # Accept either file path or direct config dict
@@ -71,6 +99,10 @@ class LegacyConfig:
         self.max_steps = self._config.get("max_steps", 20)
         self.model_providers = {}
         self.enable_lakeview = self._config.get("enable_lakeview", True)
+        self.mcp_servers = {
+            k: MCPServerConfig(**v) for k, v in self._config.get("mcp_servers", {}).items()
+        }
+        self.allow_mcp_servers = self._config.get("allow_mcp_servers", [])
 
         if len(self._config.get("model_providers", [])) == 0:
             self.model_providers = {

--- a/trae_agent/utils/mcp_client.py
+++ b/trae_agent/utils/mcp_client.py
@@ -1,0 +1,105 @@
+from contextlib import AsyncExitStack
+from enum import Enum
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from ..tools.mcp_tool import MCPTool
+from .config import MCPServerConfig
+
+
+class MCPServerStatus(Enum):
+    DISCONNECTED = "disconnected"  # Server is disconnected or experiencing errors
+    CONNECTING = "connecting"  # Server is in the process of connecting
+    CONNECTED = "connected"  # Server is connected and ready to use
+
+
+class MCPDiscoveryState(Enum):
+    """State of MCP discovery process."""
+
+    NOT_STARTED = "not_started"  # Discovery has not started yet
+    IN_PROGRESS = "in_progress"  # Discovery is currently in progress
+    # Discovery has completed (with or without errors)
+    COMPLETED = "completed"
+
+
+class MCPClient:
+    def __init__(self):
+        # Initialize session and client objects
+        self.session: ClientSession | None = None
+        self.exit_stack = AsyncExitStack()
+        self.mcp_servers_status: dict[str, MCPServerStatus] = {}
+
+    def get_mcp_server_status(self, mcp_server_name: str) -> MCPServerStatus:
+        return self.mcp_servers_status.get(mcp_server_name, MCPServerStatus.DISCONNECTED)
+
+    def update_mcp_server_status(self, mcp_server_name, status: MCPServerStatus):
+        self.mcp_servers_status[mcp_server_name] = status
+
+    async def connect_and_discover(
+        self,
+        mcp_server_name: str,
+        mcp_server_config: MCPServerConfig,
+        mcp_tools_container: list,
+        model_provider,
+    ):
+        transport = None
+        if mcp_server_config.http_url:
+            raise NotImplementedError("HTTP transport is not implemented yet")
+        elif mcp_server_config.url:
+            raise NotImplementedError("WebSocket transport is not implemented yet")
+        elif mcp_server_config.command:
+            params = StdioServerParameters(
+                command=mcp_server_config.command,
+                args=mcp_server_config.args,
+                env=mcp_server_config.env,
+                cwd=mcp_server_config.cwd,
+            )
+            transport = await self.exit_stack.enter_async_context(stdio_client(params))
+        else:
+            # error
+            raise ValueError(
+                f"Invalid MCP server configuration for {mcp_server_name}. "
+                "Please provide either a command or a URL."
+            )
+        try:
+            await self.connect_to_server(mcp_server_name, transport)
+
+            mcp_tools = await self.list_tools()
+            for tool in mcp_tools.tools:
+                mcp_tool = MCPTool(self, tool, model_provider)
+                mcp_tools_container.append(mcp_tool)
+        except Exception as e:
+            raise e
+
+    async def connect_to_server(self, mcp_server_name, transport):
+        """Connect to an MCP server
+
+        Args:
+            server_params: Parameters for connecting to the MCP server.
+        """
+        if self.get_mcp_server_status(mcp_server_name) != MCPServerStatus.CONNECTED:
+            self.update_mcp_server_status(mcp_server_name, MCPServerStatus.CONNECTING)
+            try:
+                stdio, write = transport
+                self.session = await self.exit_stack.enter_async_context(
+                    ClientSession(stdio, write)
+                )
+                await self.session.initialize()
+                self.update_mcp_server_status(mcp_server_name, MCPServerStatus.CONNECTED)
+            except Exception as e:
+                self.update_mcp_server_status(mcp_server_name, MCPServerStatus.DISCONNECTED)
+                raise e
+
+    async def call_tool(self, name, args):
+        output = await self.session.call_tool(name, args)
+        return output
+
+    async def list_tools(self):
+        tools = await self.session.list_tools()
+        return tools
+
+    async def cleanup(self, mcp_server_name):
+        """Clean up resources"""
+        await self.exit_stack.aclose()
+        self.update_mcp_server_status(mcp_server_name, MCPServerStatus.DISCONNECTED)

--- a/trae_config.json.example
+++ b/trae_config.json.example
@@ -2,6 +2,14 @@
   "default_provider": "anthropic",
   "max_steps": 20,
   "enable_lakeview": true,
+  "mcp_servers":{
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@0.0.27"
+      ]
+    }
+  },
   "model_providers": {
     "openai": {
       "api_key": "your_openai_api_key",

--- a/trae_config.yaml.example
+++ b/trae_config.yaml.example
@@ -8,7 +8,13 @@ agents:
             - str_replace_based_edit_tool
             - sequentialthinking
             - task_done
-
+allow_mcp_servers:
+    - playwright
+mcp_servers:
+    playwright:
+        command: npx
+        args:
+            - "@playwright/mcp@0.0.27"
 lakeview:
     model: lakeview_model
 

--- a/uv.lock
+++ b/uv.lock
@@ -117,6 +117,20 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncclick"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/e1e5fdf1c1bb7e6e614987c120a98d9324bf8edfaa5f5cd16a6235c9d91b/asyncclick-8.1.8.tar.gz", hash = "sha256:0f0eb0f280e04919d67cf71b9fcdfb4db2d9ff7203669c40284485c149578e4c", size = 232900, upload-time = "2025-01-06T09:46:52.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/cc/a436f0fc2d04e57a0697e0f87a03b9eaed03ad043d2d5f887f8eebcec95f/asyncclick-8.1.8-py3-none-any.whl", hash = "sha256:eb1ccb44bc767f8f0695d592c7806fdf5bd575605b4ee246ffd5fadbcfdbd7c6", size = 99093, upload-time = "2025-01-06T09:46:51.046Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/ae9e9d25522c6dc96ff167903880a0fe94d7bd31ed999198ee5017d977ed/asyncclick-8.1.8.0-py3-none-any.whl", hash = "sha256:be146a2d8075d4fe372ff4e877f23c8b5af269d16705c1948123b9415f6fd678", size = 99115, upload-time = "2025-01-06T09:50:52.72Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -484,6 +498,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/fa/66bd985dd0b7c109a3bcb89272ee0bfb7e2b4d06309ad7b38ff866734b2a/httpx_sse-0.4.1.tar.gz", hash = "sha256:8f44d34414bc7b21bf3602713005c5df4917884f76072479b21f68befa4ea26e", size = 12998, upload-time = "2025-06-24T13:21:05.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/0a/6269e3473b09aed2dab8aa1a600c70f31f00ae1349bee30658f7e358a159/httpx_sse-0.4.1-py3-none-any.whl", hash = "sha256:cba42174344c3a5b06f255ce65b350880f962d99ead85e776f23c6618a377a37", size = 8054, upload-time = "2025-06-24T13:21:04.772Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "0.33.2"
 source = { registry = "https://pypi.org/simple" }
@@ -590,6 +613,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/00/a297a868e9d0784450faa7365c2172a7d6110c763e30ba861867c32ae6a9/jsonschema-4.25.0.tar.gz", hash = "sha256:e63acf5c11762c0e6672ffb61482bdf57f0876684d8d249c0fe2d730d48bc55f", size = 356830, upload-time = "2025-07-18T15:39:45.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/54/c86cd8e011fe98803d7e382fd67c0df5ceab8d2b7ad8c5a81524f791551c/jsonschema-4.25.0-py3-none-any.whl", hash = "sha256:24c2e8da302de79c8b9382fee3e76b355e44d2a4364bb207159ce10b517bd716", size = 89184, upload-time = "2025-07-18T15:39:42.956Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/ce/46fbd9c8119cfc3581ee5643ea49464d168028cfb5caff5fc0596d0cf914/jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608", size = 15513, upload-time = "2025-04-23T12:34:07.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af", size = 18437, upload-time = "2025-04-23T12:34:05.422Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -599,6 +649,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/85/f36d538b1286b7758f35c1b69d93f2719d2df90c01bd074eadd35f6afc35/mcp-1.12.2.tar.gz", hash = "sha256:a4b7c742c50ce6ed6d6a6c096cca0e3893f5aecc89a59ed06d47c4e6ba41edcc", size = 426202, upload-time = "2025-07-24T18:29:05.175Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/cf/3fd38cfe43962452e4bfadc6966b2ea0afaf8e0286cb3991c247c8c33ebd/mcp-1.12.2-py3-none-any.whl", hash = "sha256:b86d584bb60193a42bd78aef01882c5c42d614e416cbf0480149839377ab5a5f", size = 158473, upload-time = "2025-07-24T18:29:03.419Z" },
 ]
 
 [[package]]
@@ -1028,6 +1100,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583, upload-time = "2025-06-24T13:26:46.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", size = 45235, upload-time = "2025-06-24T13:26:45.485Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1111,6 +1197,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1159,6 +1254,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775, upload-time = "2025-01-25T08:48:14.241Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1184,6 +1293,82 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078, upload-time = "2025-03-30T14:15:14.23Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229, upload-time = "2025-03-30T14:15:12.283Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/aa/4456d84bbb54adc6a916fb10c9b374f78ac840337644e4a5eda229c81275/rpds_py-0.26.0.tar.gz", hash = "sha256:20dae58a859b0906f0685642e591056f1e787f3a8b39c8e8749a45dc7d26bdb0", size = 27385, upload-time = "2025-07-01T15:57:13.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/86/90eb87c6f87085868bd077c7a9938006eb1ce19ed4d06944a90d3560fce2/rpds_py-0.26.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:894514d47e012e794f1350f076c427d2347ebf82f9b958d554d12819849a369d", size = 363933, upload-time = "2025-07-01T15:54:15.734Z" },
+    { url = "https://files.pythonhosted.org/packages/63/78/4469f24d34636242c924626082b9586f064ada0b5dbb1e9d096ee7a8e0c6/rpds_py-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc921b96fa95a097add244da36a1d9e4f3039160d1d30f1b35837bf108c21136", size = 350447, upload-time = "2025-07-01T15:54:16.922Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/91/c448ed45efdfdade82348d5e7995e15612754826ea640afc20915119734f/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e1157659470aa42a75448b6e943c895be8c70531c43cb78b9ba990778955582", size = 384711, upload-time = "2025-07-01T15:54:18.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/43/e5c86fef4be7f49828bdd4ecc8931f0287b1152c0bb0163049b3218740e7/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:521ccf56f45bb3a791182dc6b88ae5f8fa079dd705ee42138c76deb1238e554e", size = 400865, upload-time = "2025-07-01T15:54:19.295Z" },
+    { url = "https://files.pythonhosted.org/packages/55/34/e00f726a4d44f22d5c5fe2e5ddd3ac3d7fd3f74a175607781fbdd06fe375/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9def736773fd56b305c0eef698be5192c77bfa30d55a0e5885f80126c4831a15", size = 517763, upload-time = "2025-07-01T15:54:20.858Z" },
+    { url = "https://files.pythonhosted.org/packages/52/1c/52dc20c31b147af724b16104500fba13e60123ea0334beba7b40e33354b4/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdad4ea3b4513b475e027be79e5a0ceac8ee1c113a1a11e5edc3c30c29f964d8", size = 406651, upload-time = "2025-07-01T15:54:22.508Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/77/87d7bfabfc4e821caa35481a2ff6ae0b73e6a391bb6b343db2c91c2b9844/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82b165b07f416bdccf5c84546a484cc8f15137ca38325403864bfdf2b5b72f6a", size = 386079, upload-time = "2025-07-01T15:54:23.987Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d4/7f2200c2d3ee145b65b3cddc4310d51f7da6a26634f3ac87125fd789152a/rpds_py-0.26.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d04cab0a54b9dba4d278fe955a1390da3cf71f57feb78ddc7cb67cbe0bd30323", size = 421379, upload-time = "2025-07-01T15:54:25.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/13/9fdd428b9c820869924ab62236b8688b122baa22d23efdd1c566938a39ba/rpds_py-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:79061ba1a11b6a12743a2b0f72a46aa2758613d454aa6ba4f5a265cc48850158", size = 562033, upload-time = "2025-07-01T15:54:26.225Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e1/b69686c3bcbe775abac3a4c1c30a164a2076d28df7926041f6c0eb5e8d28/rpds_py-0.26.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f405c93675d8d4c5ac87364bb38d06c988e11028a64b52a47158a355079661f3", size = 591639, upload-time = "2025-07-01T15:54:27.424Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c9/1e3d8c8863c84a90197ac577bbc3d796a92502124c27092413426f670990/rpds_py-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dafd4c44b74aa4bed4b250f1aed165b8ef5de743bcca3b88fc9619b6087093d2", size = 557105, upload-time = "2025-07-01T15:54:29.93Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c5/90c569649057622959f6dcc40f7b516539608a414dfd54b8d77e3b201ac0/rpds_py-0.26.0-cp312-cp312-win32.whl", hash = "sha256:3da5852aad63fa0c6f836f3359647870e21ea96cf433eb393ffa45263a170d44", size = 223272, upload-time = "2025-07-01T15:54:31.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/16/19f5d9f2a556cfed454eebe4d354c38d51c20f3db69e7b4ce6cff904905d/rpds_py-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:cf47cfdabc2194a669dcf7a8dbba62e37a04c5041d2125fae0233b720da6f05c", size = 234995, upload-time = "2025-07-01T15:54:32.195Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f0/7935e40b529c0e752dfaa7880224771b51175fce08b41ab4a92eb2fbdc7f/rpds_py-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:20ab1ae4fa534f73647aad289003f1104092890849e0266271351922ed5574f8", size = 223198, upload-time = "2025-07-01T15:54:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/67/bb62d0109493b12b1c6ab00de7a5566aa84c0e44217c2d94bee1bd370da9/rpds_py-0.26.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:696764a5be111b036256c0b18cd29783fab22154690fc698062fc1b0084b511d", size = 363917, upload-time = "2025-07-01T15:54:34.755Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f3/34e6ae1925a5706c0f002a8d2d7f172373b855768149796af87bd65dcdb9/rpds_py-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6c15d2080a63aaed876e228efe4f814bc7889c63b1e112ad46fdc8b368b9e1", size = 350073, upload-time = "2025-07-01T15:54:36.292Z" },
+    { url = "https://files.pythonhosted.org/packages/75/83/1953a9d4f4e4de7fd0533733e041c28135f3c21485faaef56a8aadbd96b5/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:390e3170babf42462739a93321e657444f0862c6d722a291accc46f9d21ed04e", size = 384214, upload-time = "2025-07-01T15:54:37.469Z" },
+    { url = "https://files.pythonhosted.org/packages/48/0e/983ed1b792b3322ea1d065e67f4b230f3b96025f5ce3878cc40af09b7533/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7da84c2c74c0f5bc97d853d9e17bb83e2dcafcff0dc48286916001cc114379a1", size = 400113, upload-time = "2025-07-01T15:54:38.954Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7f/36c0925fff6f660a80be259c5b4f5e53a16851f946eb080351d057698528/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4c5fe114a6dd480a510b6d3661d09d67d1622c4bf20660a474507aaee7eeeee9", size = 515189, upload-time = "2025-07-01T15:54:40.57Z" },
+    { url = "https://files.pythonhosted.org/packages/13/45/cbf07fc03ba7a9b54662c9badb58294ecfb24f828b9732970bd1a431ed5c/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3100b3090269f3a7ea727b06a6080d4eb7439dca4c0e91a07c5d133bb1727ea7", size = 406998, upload-time = "2025-07-01T15:54:43.025Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/b0/8fa5e36e58657997873fd6a1cf621285ca822ca75b4b3434ead047daa307/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c03c9b0c64afd0320ae57de4c982801271c0c211aa2d37f3003ff5feb75bb04", size = 385903, upload-time = "2025-07-01T15:54:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f7/b25437772f9f57d7a9fbd73ed86d0dcd76b4c7c6998348c070d90f23e315/rpds_py-0.26.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5963b72ccd199ade6ee493723d18a3f21ba7d5b957017607f815788cef50eaf1", size = 419785, upload-time = "2025-07-01T15:54:46.043Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/63ffa55743dfcb4baf2e9e77a0b11f7f97ed96a54558fcb5717a4b2cd732/rpds_py-0.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9da4e873860ad5bab3291438525cae80169daecbfafe5657f7f5fb4d6b3f96b9", size = 561329, upload-time = "2025-07-01T15:54:47.64Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/07/1f4f5e2886c480a2346b1e6759c00278b8a69e697ae952d82ae2e6ee5db0/rpds_py-0.26.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5afaddaa8e8c7f1f7b4c5c725c0070b6eed0228f705b90a1732a48e84350f4e9", size = 590875, upload-time = "2025-07-01T15:54:48.9Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/bc/e6639f1b91c3a55f8c41b47d73e6307051b6e246254a827ede730624c0f8/rpds_py-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4916dc96489616a6f9667e7526af8fa693c0fdb4f3acb0e5d9f4400eb06a47ba", size = 556636, upload-time = "2025-07-01T15:54:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/05/4c/b3917c45566f9f9a209d38d9b54a1833f2bb1032a3e04c66f75726f28876/rpds_py-0.26.0-cp313-cp313-win32.whl", hash = "sha256:2a343f91b17097c546b93f7999976fd6c9d5900617aa848c81d794e062ab302b", size = 222663, upload-time = "2025-07-01T15:54:52.023Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0b/0851bdd6025775aaa2365bb8de0697ee2558184c800bfef8d7aef5ccde58/rpds_py-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:0a0b60701f2300c81b2ac88a5fb893ccfa408e1c4a555a77f908a2596eb875a5", size = 234428, upload-time = "2025-07-01T15:54:53.692Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/e8/a47c64ed53149c75fb581e14a237b7b7cd18217e969c30d474d335105622/rpds_py-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:257d011919f133a4746958257f2c75238e3ff54255acd5e3e11f3ff41fd14256", size = 222571, upload-time = "2025-07-01T15:54:54.822Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bf/3d970ba2e2bcd17d2912cb42874107390f72873e38e79267224110de5e61/rpds_py-0.26.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:529c8156d7506fba5740e05da8795688f87119cce330c244519cf706a4a3d618", size = 360475, upload-time = "2025-07-01T15:54:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/82/9f/283e7e2979fc4ec2d8ecee506d5a3675fce5ed9b4b7cb387ea5d37c2f18d/rpds_py-0.26.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f53ec51f9d24e9638a40cabb95078ade8c99251945dad8d57bf4aabe86ecee35", size = 346692, upload-time = "2025-07-01T15:54:58.561Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/03/7e50423c04d78daf391da3cc4330bdb97042fc192a58b186f2d5deb7befd/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab504c4d654e4a29558eaa5bb8cea5fdc1703ea60a8099ffd9c758472cf913f", size = 379415, upload-time = "2025-07-01T15:54:59.751Z" },
+    { url = "https://files.pythonhosted.org/packages/57/00/d11ee60d4d3b16808432417951c63df803afb0e0fc672b5e8d07e9edaaae/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd0641abca296bc1a00183fe44f7fced8807ed49d501f188faa642d0e4975b83", size = 391783, upload-time = "2025-07-01T15:55:00.898Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/1069c394d9c0d6d23c5b522e1f6546b65793a22950f6e0210adcc6f97c3e/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:69b312fecc1d017b5327afa81d4da1480f51c68810963a7336d92203dbb3d4f1", size = 512844, upload-time = "2025-07-01T15:55:02.201Z" },
+    { url = "https://files.pythonhosted.org/packages/08/3b/c4fbf0926800ed70b2c245ceca99c49f066456755f5d6eb8863c2c51e6d0/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c741107203954f6fc34d3066d213d0a0c40f7bb5aafd698fb39888af277c70d8", size = 402105, upload-time = "2025-07-01T15:55:03.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b0/db69b52ca07413e568dae9dc674627a22297abb144c4d6022c6d78f1e5cc/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc3e55a7db08dc9a6ed5fb7103019d2c1a38a349ac41901f9f66d7f95750942f", size = 383440, upload-time = "2025-07-01T15:55:05.398Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/e1/c65255ad5b63903e56b3bb3ff9dcc3f4f5c3badde5d08c741ee03903e951/rpds_py-0.26.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9e851920caab2dbcae311fd28f4313c6953993893eb5c1bb367ec69d9a39e7ed", size = 412759, upload-time = "2025-07-01T15:55:08.316Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/22/bb731077872377a93c6e93b8a9487d0406c70208985831034ccdeed39c8e/rpds_py-0.26.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dfbf280da5f876d0b00c81f26bedce274e72a678c28845453885a9b3c22ae632", size = 556032, upload-time = "2025-07-01T15:55:09.52Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/8b/393322ce7bac5c4530fb96fc79cc9ea2f83e968ff5f6e873f905c493e1c4/rpds_py-0.26.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1cc81d14ddfa53d7f3906694d35d54d9d3f850ef8e4e99ee68bc0d1e5fed9a9c", size = 585416, upload-time = "2025-07-01T15:55:11.216Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ae/769dc372211835bf759319a7aae70525c6eb523e3371842c65b7ef41c9c6/rpds_py-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dca83c498b4650a91efcf7b88d669b170256bf8017a5db6f3e06c2bf031f57e0", size = 554049, upload-time = "2025-07-01T15:55:13.004Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f9/4c43f9cc203d6ba44ce3146246cdc38619d92c7bd7bad4946a3491bd5b70/rpds_py-0.26.0-cp313-cp313t-win32.whl", hash = "sha256:4d11382bcaf12f80b51d790dee295c56a159633a8e81e6323b16e55d81ae37e9", size = 218428, upload-time = "2025-07-01T15:55:14.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8b/9286b7e822036a4a977f2f1e851c7345c20528dbd56b687bb67ed68a8ede/rpds_py-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff110acded3c22c033e637dd8896e411c7d3a11289b2edf041f86663dbc791e9", size = 231524, upload-time = "2025-07-01T15:55:15.745Z" },
+    { url = "https://files.pythonhosted.org/packages/55/07/029b7c45db910c74e182de626dfdae0ad489a949d84a468465cd0ca36355/rpds_py-0.26.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:da619979df60a940cd434084355c514c25cf8eb4cf9a508510682f6c851a4f7a", size = 364292, upload-time = "2025-07-01T15:55:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d1/9b3d3f986216b4d1f584878dca15ce4797aaf5d372d738974ba737bf68d6/rpds_py-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea89a2458a1a75f87caabefe789c87539ea4e43b40f18cff526052e35bbb4fdf", size = 350334, upload-time = "2025-07-01T15:55:18.922Z" },
+    { url = "https://files.pythonhosted.org/packages/18/98/16d5e7bc9ec715fa9668731d0cf97f6b032724e61696e2db3d47aeb89214/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:feac1045b3327a45944e7dcbeb57530339f6b17baff154df51ef8b0da34c8c12", size = 384875, upload-time = "2025-07-01T15:55:20.399Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/13/aa5e2b1ec5ab0e86a5c464d53514c0467bec6ba2507027d35fc81818358e/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b818a592bd69bfe437ee8368603d4a2d928c34cffcdf77c2e761a759ffd17d20", size = 399993, upload-time = "2025-07-01T15:55:21.729Z" },
+    { url = "https://files.pythonhosted.org/packages/17/03/8021810b0e97923abdbab6474c8b77c69bcb4b2c58330777df9ff69dc559/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1a8b0dd8648709b62d9372fc00a57466f5fdeefed666afe3fea5a6c9539a0331", size = 516683, upload-time = "2025-07-01T15:55:22.918Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b1/da8e61c87c2f3d836954239fdbbfb477bb7b54d74974d8f6fcb34342d166/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6d3498ad0df07d81112aa6ec6c95a7e7b1ae00929fb73e7ebee0f3faaeabad2f", size = 408825, upload-time = "2025-07-01T15:55:24.207Z" },
+    { url = "https://files.pythonhosted.org/packages/38/bc/1fc173edaaa0e52c94b02a655db20697cb5fa954ad5a8e15a2c784c5cbdd/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24a4146ccb15be237fdef10f331c568e1b0e505f8c8c9ed5d67759dac58ac246", size = 387292, upload-time = "2025-07-01T15:55:25.554Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/eb/3a9bb4bd90867d21916f253caf4f0d0be7098671b6715ad1cead9fe7bab9/rpds_py-0.26.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a9a63785467b2d73635957d32a4f6e73d5e4df497a16a6392fa066b753e87387", size = 420435, upload-time = "2025-07-01T15:55:27.798Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/16/e066dcdb56f5632713445271a3f8d3d0b426d51ae9c0cca387799df58b02/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:de4ed93a8c91debfd5a047be327b7cc8b0cc6afe32a716bbbc4aedca9e2a83af", size = 562410, upload-time = "2025-07-01T15:55:29.057Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/ddbdec7eb82a0dc2e455be44c97c71c232983e21349836ce9f272e8a3c29/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:caf51943715b12af827696ec395bfa68f090a4c1a1d2509eb4e2cb69abbbdb33", size = 590724, upload-time = "2025-07-01T15:55:30.719Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/95744085e65b7187d83f2fcb0bef70716a1ea0a9e5d8f7f39a86e5d83424/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4a59e5bc386de021f56337f757301b337d7ab58baa40174fb150accd480bc953", size = 558285, upload-time = "2025-07-01T15:55:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/37/37/6309a75e464d1da2559446f9c811aa4d16343cebe3dbb73701e63f760caa/rpds_py-0.26.0-cp314-cp314-win32.whl", hash = "sha256:92c8db839367ef16a662478f0a2fe13e15f2227da3c1430a782ad0f6ee009ec9", size = 223459, upload-time = "2025-07-01T15:55:33.312Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/6f/8e9c11214c46098b1d1391b7e02b70bb689ab963db3b19540cba17315291/rpds_py-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:b0afb8cdd034150d4d9f53926226ed27ad15b7f465e93d7468caaf5eafae0d37", size = 236083, upload-time = "2025-07-01T15:55:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/47/af/9c4638994dd623d51c39892edd9d08e8be8220a4b7e874fa02c2d6e91955/rpds_py-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:ca3f059f4ba485d90c8dc75cb5ca897e15325e4e609812ce57f896607c1c0867", size = 223291, upload-time = "2025-07-01T15:55:36.202Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/db/669a241144460474aab03e254326b32c42def83eb23458a10d163cb9b5ce/rpds_py-0.26.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5afea17ab3a126006dc2f293b14ffc7ef3c85336cf451564a0515ed7648033da", size = 361445, upload-time = "2025-07-01T15:55:37.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2d/133f61cc5807c6c2fd086a46df0eb8f63a23f5df8306ff9f6d0fd168fecc/rpds_py-0.26.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:69f0c0a3df7fd3a7eec50a00396104bb9a843ea6d45fcc31c2d5243446ffd7a7", size = 347206, upload-time = "2025-07-01T15:55:38.828Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bf/0e8fb4c05f70273469eecf82f6ccf37248558526a45321644826555db31b/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:801a71f70f9813e82d2513c9a96532551fce1e278ec0c64610992c49c04c2dad", size = 380330, upload-time = "2025-07-01T15:55:40.175Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/a8/060d24185d8b24d3923322f8d0ede16df4ade226a74e747b8c7c978e3dd3/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:df52098cde6d5e02fa75c1f6244f07971773adb4a26625edd5c18fee906fa84d", size = 392254, upload-time = "2025-07-01T15:55:42.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/7b/7c2e8a9ee3e6bc0bae26bf29f5219955ca2fbb761dca996a83f5d2f773fe/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9bc596b30f86dc6f0929499c9e574601679d0341a0108c25b9b358a042f51bca", size = 516094, upload-time = "2025-07-01T15:55:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/75/d6/f61cafbed8ba1499b9af9f1777a2a199cd888f74a96133d8833ce5eaa9c5/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9dfbe56b299cf5875b68eb6f0ebaadc9cac520a1989cac0db0765abfb3709c19", size = 402889, upload-time = "2025-07-01T15:55:45.275Z" },
+    { url = "https://files.pythonhosted.org/packages/92/19/c8ac0a8a8df2dd30cdec27f69298a5c13e9029500d6d76718130f5e5be10/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac64f4b2bdb4ea622175c9ab7cf09444e412e22c0e02e906978b3b488af5fde8", size = 384301, upload-time = "2025-07-01T15:55:47.098Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e1/6b1859898bc292a9ce5776016c7312b672da00e25cec74d7beced1027286/rpds_py-0.26.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:181ef9b6bbf9845a264f9aa45c31836e9f3c1f13be565d0d010e964c661d1e2b", size = 412891, upload-time = "2025-07-01T15:55:48.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/b9/ceb39af29913c07966a61367b3c08b4f71fad841e32c6b59a129d5974698/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:49028aa684c144ea502a8e847d23aed5e4c2ef7cadfa7d5eaafcb40864844b7a", size = 557044, upload-time = "2025-07-01T15:55:49.816Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/27/35637b98380731a521f8ec4f3fd94e477964f04f6b2f8f7af8a2d889a4af/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e5d524d68a474a9688336045bbf76cb0def88549c1b2ad9dbfec1fb7cfbe9170", size = 585774, upload-time = "2025-07-01T15:55:51.192Z" },
+    { url = "https://files.pythonhosted.org/packages/52/d9/3f0f105420fecd18551b678c9a6ce60bd23986098b252a56d35781b3e7e9/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1851f429b822831bd2edcbe0cfd12ee9ea77868f8d3daf267b189371671c80e", size = 554886, upload-time = "2025-07-01T15:55:52.541Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/c5/347c056a90dc8dd9bc240a08c527315008e1b5042e7a4cf4ac027be9d38a/rpds_py-0.26.0-cp314-cp314t-win32.whl", hash = "sha256:7bdb17009696214c3b66bb3590c6d62e14ac5935e53e929bcdbc5a495987a84f", size = 219027, upload-time = "2025-07-01T15:55:53.874Z" },
+    { url = "https://files.pythonhosted.org/packages/75/04/5302cea1aa26d886d34cadbf2dc77d90d7737e576c0065f357b96dc7a1a6/rpds_py-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f14440b9573a6f76b4ee4770c13f0b5921f71dde3b6fcb8dabbefd13b7fe05d7", size = 232821, upload-time = "2025-07-01T15:55:55.167Z" },
 ]
 
 [[package]]
@@ -1251,6 +1436,31 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/6f/22ed6e33f8a9e76ca0a412405f31abb844b779d52c5f96660766edcd737c/sse_starlette-3.0.2.tar.gz", hash = "sha256:ccd60b5765ebb3584d0de2d7a6e4f745672581de4f5005ab31c3a25d10b52b3a", size = 20985, upload-time = "2025-07-27T09:07:44.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/10/c78f463b4ef22eef8491f218f692be838282cd65480f6e423d7730dfd1fb/sse_starlette-3.0.2-py3-none-any.whl", hash = "sha256:16b7cbfddbcd4eaca11f7b586f3b8a080f1afe952c15813455b162edea619e5a", size = 11297, upload-time = "2025-07-27T09:07:43.268Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.47.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/57/d062573f391d062710d4088fa1369428c38d51460ab6fedff920efef932e/starlette-0.47.2.tar.gz", hash = "sha256:6ae9aa5db235e4846decc1e7b79c4f346adf41e9777aebeb49dfd09bbd7023d8", size = 2583948, upload-time = "2025-07-20T17:31:58.522Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/1f/b876b1f83aef204198a42dc101613fefccb32258e5428b5f9259677864b4/starlette-0.47.2-py3-none-any.whl", hash = "sha256:c5847e96134e5c5371ee9fac6fdf1a67336d5815e09eb2a01fdb57a351ef915b", size = 72984, upload-time = "2025-07-20T17:31:56.738Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1277,9 +1487,11 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "asyncclick" },
     { name = "click" },
     { name = "google-genai" },
     { name = "jsonpath-ng" },
+    { name = "mcp" },
     { name = "ollama" },
     { name = "openai" },
     { name = "pydantic" },
@@ -1314,11 +1526,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.54.0" },
+    { name = "asyncclick", specifier = ">=8.0.0" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "datasets", marker = "extra == 'evaluation'", specifier = ">=3.6.0" },
     { name = "docker", marker = "extra == 'evaluation'", specifier = ">=7.1.0" },
     { name = "google-genai", specifier = ">=1.24.0" },
     { name = "jsonpath-ng", specifier = ">=1.7.0" },
+    { name = "mcp", specifier = "==1.12.2" },
     { name = "ollama", specifier = ">=0.5.1" },
     { name = "openai", specifier = ">=1.86.0" },
     { name = "pre-commit", marker = "extra == 'test'", specifier = ">=4.2.0" },
@@ -1422,6 +1636,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/42/e0e305207bb88c6b8d3061399c6a961ffe5fbb7e2aa63c9234df7259e9cd/uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01", size = 78473, upload-time = "2025-06-28T16:15:46.058Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a", size = 66406, upload-time = "2025-06-28T16:15:44.816Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces a new feature that implements the basic tool invocation functionality for the MCP service. It establishes the foundational workflow for invoking tools via MCP, laying the groundwork for future expansions.

More Information
This feature enables the end-to-end tool invocation process through the MCP server.

Currently, only the stdio transport is supported for communication with the MCP server.

Other transport types will be added in future updates as the implementation progresses.

Validation
Start the MCP server with the stdio transport.

Use the client to connect to the server and verify that tool discovery and invocation work as expected.

Check that responses are received and handled correctly from the server.

Linked Issues
Resolves #85 