### PR TITLE
Rename default_model to trae_agent_model in config

### DIFF
--- a/trae_config.yaml.example
+++ b/trae_config.yaml.example
@@ -24,7 +24,7 @@ model_providers:
         provider: anthropic
 
 models:
-    default_model:
+    trae_agent_model:
         model_provider: anthropic
         model: claude-4-sonnet
         max_tokens: 4096


### PR DESCRIPTION

## Description

Updated the example configuration to use 'trae_agent_model' instead of 'default_model' for clarity and consistency.

