### PR TITLE
Change default config file to YAML format

### DIFF
--- a/trae_agent/cli.py
+++ b/trae_agent/cli.py
@@ -330,7 +330,7 @@ async def interactive(
 @click.option(
     "--config-file",
     help="Path to configuration file",
-    default="trae_config.json",
+    default="trae_config.yaml",
     envvar="TRAE_CONFIG_FILE",
 )
 @click.option("--provider", "-p", help="LLM provider to use")


### PR DESCRIPTION

## Description

Updated the --config-file option to use 'trae_config.yaml' as the default instead of 'trae_config.json' to reflect a switch to YAML configuration.
