### PR TITLE
Debug: Handling Config with YAML file

### DIFF
--- a/trae_agent/utils/config.py
+++ b/trae_agent/utils/config.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import os
+from pathlib import Path
 from dataclasses import dataclass, field
 
 import yaml
@@ -194,10 +195,19 @@ class Config:
             raise ConfigError("Only one of config_file or config_string should be provided")
 
         # Parse YAML config from file or string
+        if (
+            config_file is not None
+            and config_file.endswith(".json")
+            and Path("./" + config_file).is_file()
+        ):
+            return cls.create_from_legacy_config(config_file=config_file)
+
+        if config_file and config_file.endswith(".json"):
+            # we have already checked the json doesn't work
+            config_file = config_file[:-5] + ".yaml"
+
         try:
             if config_file is not None:
-                if config_file.endswith(".json"):
-                    return cls.create_from_legacy_config(config_file=config_file)
                 with open(config_file, "r") as f:
                     yaml_config = yaml.safe_load(f)
             elif config_string is not None:


### PR DESCRIPTION
## Description

Currently, if the directory is used with either interactive or show‑config, the YAML configuration is not displayed; the program tries to readonly  the JSON file instead.

Therefore I added a few lines of debug code to fix the issue: read the YAML file when the JSON file does not exist in the directory.

## More Information

N/A

## Validation
Both show config and interactive status works fine.

## Linked Issues
N/A