### PR TITLE
fix(agent): Correctly set AgentExecution running and error states

### DIFF
--- a/trae_agent/agent/base_agent.py
+++ b/trae_agent/agent/base_agent.py
@@ -119,6 +119,7 @@ class BaseAgent(ABC):
         try:
             messages = self._initial_messages
             step_number = 1
+            execution.agent_state = AgentState.RUNNING
 
             while step_number <= self._max_steps:
                 step = AgentStep(step_number=step_number, state=AgentStepState.THINKING)
@@ -139,6 +140,7 @@ class BaseAgent(ABC):
 
             if step_number > self._max_steps and not execution.success:
                 execution.final_result = "Task execution exceeded maximum steps without completion."
+                execution.agent_state = AgentState.ERROR
 
         except Exception as e:
             execution.final_result = f"Agent execution failed: {str(e)}"


### PR DESCRIPTION
Sets the AgentExecution state to RUNNING at the start of a task and to ERROR when max steps are exceeded.

## Description

<!-- Add a brief description about this pull request including what it does, why it is needed, and other important information for the reviewers -->
This pull request fixes a bug in the `AgentExecution` state management. Previously, the agent's state was not accurately reflected during its lifecycle, leading to two main issues:
1.  A running task may incorrectly remain in its initial `IDLE` state.
2.  Tasks that failed by exceeding the maximum step limit may cause the `trae-cli` to hang indefinitely.

This change ensures the `agent_state` is now correctly set to `RUNNING` at the start of a task and to `ERROR` when the step limit is reached, making the agent's lifecycle robust and observable.

## More Information

<!-- Add more in-depth information about this pull request, such as the changes made, the reasoning behind them, and any potential impacts. -->
**Missing `ERROR` State on Max Steps:**
    -   If a task reached the max_steps limit without being successful, the `agent_execution.agent_state` would remain `AgentState.IDLE`, causing the `cli_console_task` to get stuck in an infinite wait loop. The console was expecting a terminal state that would never arrive, making the application hang indefinitely.
 
```python
@override
    async def start(self):
        """Start the console - wait for completion and then print summary."""
        while self.agent_execution is None or (
            self.agent_execution.agent_state != AgentState.COMPLETED
            and self.agent_execution.agent_state != AgentState.ERROR
        ):
            await asyncio.sleep(1)
```

## Validation

<!-- Introduce how to test this pull request. -->

## Linked Issues

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
