### PR TITLE
hotfix: `_BashSession.stop()` may might hang on Windows

### DIFF
--- a/tests/tools/test_bash_tool.py
+++ b/tests/tools/test_bash_tool.py
@@ -14,7 +14,7 @@ class TestBashTool(unittest.IsolatedAsyncioTestCase):
     async def asyncTearDown(self):
         # Cleanup any active session
         if self.tool._session:
-            self.tool._session.stop()
+            await self.tool._session.stop()
 
     async def test_tool_initialization(self):
         self.assertEqual(self.tool.get_name(), "bash")

--- a/trae_agent/agent/base_agent.py
+++ b/trae_agent/agent/base_agent.py
@@ -155,11 +155,13 @@ class BaseAgent(ABC):
 
         self._update_cli_console(step, execution)
         return execution
-        
+
     async def _close_tools(self):
         """Release tool resources, mainly about BashTool object."""
         if self._tool_caller:
-            res = await self._tool_caller.close_tools() # Ensure all tool resources are properly released.
+            # Ensure all tool resources are properly released.
+            res = await self._tool_caller.close_tools()
+            return res
 
     async def _run_llm_step(
         self, step: "AgentStep", messages: list["LLMMessage"], execution: "AgentExecution"

--- a/trae_agent/agent/base_agent.py
+++ b/trae_agent/agent/base_agent.py
@@ -125,7 +125,7 @@ class BaseAgent(ABC):
                 step = AgentStep(step_number=step_number, state=AgentStepState.THINKING)
                 try:
                     messages = await self._run_llm_step(step, messages, execution)
-                    self._finalize_step(
+                    await self._finalize_step(
                         step, messages, execution
                     )  # record trajectory for this step and update the CLI console
                     if execution.agent_state == AgentState.COMPLETED:
@@ -135,15 +135,17 @@ class BaseAgent(ABC):
                     execution.agent_state = AgentState.ERROR
                     step.state = AgentStepState.ERROR
                     step.error = str(error)
-                    self._finalize_step(step, messages, execution)
+                    await self._finalize_step(step, messages, execution)
                     break
-
             if step_number > self._max_steps and not execution.success:
                 execution.final_result = "Task execution exceeded maximum steps without completion."
                 execution.agent_state = AgentState.ERROR
 
         except Exception as e:
             execution.final_result = f"Agent execution failed: {str(e)}"
+
+        # Ensure tool resources are released whether an exception occurs or not.
+        await self._close_tools()
 
         execution.execution_time = time.time() - start_time
 
@@ -153,6 +155,11 @@ class BaseAgent(ABC):
 
         self._update_cli_console(step, execution)
         return execution
+        
+    async def _close_tools(self):
+        """Release tool resources, mainly about BashTool object."""
+        if self._tool_caller:
+            res = await self._tool_caller.close_tools() # Ensure all tool resources are properly released.
 
     async def _run_llm_step(
         self, step: "AgentStep", messages: list["LLMMessage"], execution: "AgentExecution"
@@ -183,7 +190,7 @@ class BaseAgent(ABC):
             tool_calls = llm_response.tool_calls
             return await self._tool_call_handler(tool_calls, step)
 
-    def _finalize_step(
+    async def _finalize_step(
         self, step: "AgentStep", messages: list["LLMMessage"], execution: "AgentExecution"
     ) -> None:
         step.state = AgentStepState.COMPLETED

--- a/trae_agent/tools/base.py
+++ b/trae_agent/tools/base.py
@@ -173,7 +173,7 @@ class Tool(ABC):
             schema["additionalProperties"] = False
 
         return schema
-        
+
     async def close(self):
         """Ensure proper tool resource deallocation before task completion."""
         pass
@@ -185,10 +185,9 @@ class ToolExecutor:
     def __init__(self, tools: list[Tool]):
         self._tools = tools
         self._tool_map: dict[str, Tool] | None = None
-        
+
     async def close_tools(self):
         """Ensure all tool resources are properly released."""
-        #for tool in self._tools:
         tasks = [tool.close() for tool in self._tools if hasattr(tool, "close")]
         res = await asyncio.gather(*tasks)
         return res

--- a/trae_agent/tools/base.py
+++ b/trae_agent/tools/base.py
@@ -176,7 +176,7 @@ class Tool(ABC):
 
     async def close(self):
         """Ensure proper tool resource deallocation before task completion."""
-        pass
+        return None # Using "pass" will trigger a Ruff check error: E027
 
 
 class ToolExecutor:

--- a/trae_agent/tools/base.py
+++ b/trae_agent/tools/base.py
@@ -176,7 +176,7 @@ class Tool(ABC):
 
     async def close(self):
         """Ensure proper tool resource deallocation before task completion."""
-        return None # Using "pass" will trigger a Ruff check error: B027
+        return None  # Using "pass" will trigger a Ruff check error: B027
 
 
 class ToolExecutor:

--- a/trae_agent/tools/base.py
+++ b/trae_agent/tools/base.py
@@ -173,6 +173,10 @@ class Tool(ABC):
             schema["additionalProperties"] = False
 
         return schema
+        
+    async def close(self):
+        """Ensure proper tool resource deallocation before task completion."""
+        pass
 
 
 class ToolExecutor:
@@ -181,6 +185,13 @@ class ToolExecutor:
     def __init__(self, tools: list[Tool]):
         self._tools = tools
         self._tool_map: dict[str, Tool] | None = None
+        
+    async def close_tools(self):
+        """Ensure all tool resources are properly released."""
+        #for tool in self._tools:
+        tasks = [tool.close() for tool in self._tools if hasattr(tool, "close")]
+        res = await asyncio.gather(*tasks)
+        return res
 
     def _normalize_name(self, name: str) -> str:
         """Normalize tool name by making it lowercase and removing underscores."""

--- a/trae_agent/tools/base.py
+++ b/trae_agent/tools/base.py
@@ -176,7 +176,7 @@ class Tool(ABC):
 
     async def close(self):
         """Ensure proper tool resource deallocation before task completion."""
-        return None # Using "pass" will trigger a Ruff check error: E027
+        return None # Using "pass" will trigger a Ruff check error: B027
 
 
 class ToolExecutor:

--- a/trae_agent/tools/bash_tool.py
+++ b/trae_agent/tools/bash_tool.py
@@ -60,7 +60,7 @@ class _BashSession:
 
         self._started = True
 
-    def stop(self) -> None:
+    async def stop(self) -> None:
         """Terminate the bash shell."""
         if not self._started:
             raise ToolError("Session has not started.")
@@ -69,6 +69,9 @@ class _BashSession:
         if self._process.returncode is not None:
             return
         self._process.terminate()
+        
+        # Wait until the process has truly terminated.
+        stdout, stderr = await self._process.communicate()
 
     async def run(self, command: str) -> ToolExecResult:
         """Execute a command in the bash shell."""
@@ -199,7 +202,7 @@ class BashTool(Tool):
     async def execute(self, arguments: ToolCallArguments) -> ToolExecResult:
         if arguments.get("restart"):
             if self._session:
-                self._session.stop()
+                await self._session.stop()
             self._session = _BashSession()
             await self._session.start()
 
@@ -222,3 +225,11 @@ class BashTool(Tool):
             return await self._session.run(command)
         except Exception as e:
             return ToolExecResult(error=f"Error running bash command: {e}", error_code=-1)
+
+    @override
+    async def close(self):
+        """Properly close self._process."""
+        if self._session:
+            ret = await self._session.stop()
+            self._session = None
+            return ret

--- a/trae_agent/tools/bash_tool.py
+++ b/trae_agent/tools/bash_tool.py
@@ -69,7 +69,7 @@ class _BashSession:
         if self._process.returncode is not None:
             return
         self._process.terminate()
-        
+
         # Wait until the process has truly terminated.
         stdout, stderr = await self._process.communicate()
 


### PR DESCRIPTION
## Description

This PR serves as a hotfix for the bug caused by my previous PR #288.

On Windows, when a `BashTool` object's command execution (e.g., npm run dev) times out, the `BashTool` object may subsequently hang during the execution of `self._session._process.stop()`, specifically at the `self._process.communicate()` method within the `_BashSession.stop()` method.

Analysis(by Qwen3-Coder-plus, and DeepSeek-v3.1) suggests that this issue may arise from differences in process models between Windows and Linux. The termination behavior of process objects created via asyncio.create_subprocess_shellon Windows may be more complex, potentially leading to the problem.

To resolve this issue, I replaced `await self._process.communicate()` with `await asyncio.wait_for(self._process.communicate(), timeout=5.0)` and  added exception handling to handle `asyncio.wait_for` execution timeouts.

I sincerely apologize for the new bug caused by insufficient case testing in my previous PR!

## More Information

None

## Validation

- Windows: `ruff format .` & `ruff check --fix .` & Manual verification with real cases.
- Linux: `make fix-format` & `make test`.

## Linked Issues

None, for now.
