### PR TITLE
Adding new method to some commonly used struct 

### DIFF
--- a/trae_agent_rs/core/src/llm/mod.rs
+++ b/trae_agent_rs/core/src/llm/mod.rs
@@ -55,6 +55,23 @@ impl LLMUsage {
             reasoning_tokens: self.reasoning_tokens + other.reasoning_tokens,
         }
     }
+
+    pub fn new(
+        input_token:i32, 
+        output_token:i32,
+        cache_creation_input_tokens:i32, 
+        cache_read_input_tokens:i32, 
+        reasoing_tokens:i32)
+    -> Self{
+        LLMUsage { 
+            input_tokens: input_token, 
+            output_tokens: output_token, 
+            cache_creation_input_tokens: cache_creation_input_tokens, 
+            cache_read_input_tokens: cache_read_input_tokens, 
+            reasoning_tokens: reasoing_tokens, 
+        }
+    }
+
 }
 
 impl std::ops::Add for LLMUsage {
@@ -109,6 +126,26 @@ pub struct LLMResponse {
     pub tool_calls: Option<Vec<ToolCall>>,
 }
 
+
+impl LLMResponse{
+    fn new(
+        content:String, 
+        usage: Option<LLMUsage>, 
+        model: Option<String>,
+        finish_reason: Option<String>,
+        tool_calls: Option<Vec<ToolCall>>,
+    )-> Self{
+        LLMResponse { 
+            content: content, 
+            usage: usage, 
+            model: model, 
+            finish_reason: finish_reason, 
+            tool_calls: tool_calls 
+        }
+    }
+
+}
+
 /// Stream chunk for streaming responses
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StreamChunk {
@@ -118,6 +155,26 @@ pub struct StreamChunk {
     pub tool_calls: Option<Vec<ToolCall>>,
     pub usage: Option<LLMUsage>,
 }
+
+
+impl StreamChunk {
+    fn new(
+        content: Option<String>, 
+        finished_reason: Option<String>,
+        model: Option<String>,
+        tool_calls: Option<Vec<ToolCall>>,
+        usage: Option<LLMUsage>
+    )-> Self {
+        StreamChunk { 
+            content: content, 
+            finish_reason: finished_reason, 
+            model: model, 
+            tool_calls: tool_calls, 
+            usage: usage,
+        } 
+    }
+}
+
 
 /// Type alias for streaming response
 pub type LLMStream = Pin<Box<dyn Stream<Item = LLMResult<StreamChunk>> + Send>>;

--- a/trae_agent_rs/core/src/llm/mod.rs
+++ b/trae_agent_rs/core/src/llm/mod.rs
@@ -128,7 +128,7 @@ pub struct LLMResponse {
 
 
 impl LLMResponse{
-    fn new(
+    pub fn new(
         content:String, 
         usage: Option<LLMUsage>, 
         model: Option<String>,
@@ -158,7 +158,7 @@ pub struct StreamChunk {
 
 
 impl StreamChunk {
-    fn new(
+    pub fn new(
         content: Option<String>, 
         finished_reason: Option<String>,
         model: Option<String>,

--- a/trae_agent_rs/core/src/tools/mod.rs
+++ b/trae_agent_rs/core/src/tools/mod.rs
@@ -18,6 +18,24 @@ pub struct ToolResult {
     pub id: Option<String>, // OpenAI-specific field
 }
 
+impl ToolResult {
+
+    pub fn new(
+        call_id: String,
+        name: String,
+    ) -> Self{
+        ToolResult { 
+            call_id: call_id, 
+            name: name, 
+            success: false, 
+            result: None, 
+            error: None, 
+            id: None 
+        }
+    }
+
+}
+
 /// Represents a parsed tool call
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolCall {
@@ -27,6 +45,9 @@ pub struct ToolCall {
     pub arguments: ToolCallArguments,
     pub id: Option<String>,
 }
+
+// don't implement new for tool call cause tool call actually depends on the argument which 
+// may cause problem when developer randomly call the Tool Call
 
 impl fmt::Display for ToolCall {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
## Description
Currently, when creating a new object from the struct, you have to manually type out every field. This is annoying and inefficient. To address these problems, we should introduce some new methods.
This PR provides a few new methods for some commonly used structs. There are many more possible, but these few are the most commonly used.

## More Information
This is just some very typical new method in rust as saw in the rust book . 
@chao-peng  PTAL. 

## Validation
N/A; This PR will not affect any code that have already implemented. 


## Linked Issues
N/A