### PR TITLE
feat: Add DeepSeek and Qwen LLM client support - Add DeepSeekClient w…

### DIFF
--- a/tests/utils/test_deepseek_client.py
+++ b/tests/utils/test_deepseek_client.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: MIT
+
+"""
+Unit tests for the DeepSeekClient.
+
+WARNING: These tests should not be run in a GitHub Actions workflow
+because they require an API key.
+"""
+
+import os
+import unittest
+
+from trae_agent.utils.config import ModelConfig, ModelProvider
+from trae_agent.utils.llm_clients.deepseek_client import DeepSeekClient
+from trae_agent.utils.llm_clients.llm_basics import LLMMessage
+
+TEST_MODEL = "deepseek-chat"
+
+
+@unittest.skipIf(
+    os.getenv("SKIP_DEEPSEEK_TEST", "").lower() == "true",
+    "DeepSeek tests skipped due to SKIP_DEEPSEEK_TEST environment variable",
+)
+class TestDeepSeekClient(unittest.TestCase):
+    def test_deepseek_client_init(self):
+        """Test the initialization of the DeepSeekClient."""
+        model_config = ModelConfig(
+            model=TEST_MODEL,
+            model_provider=ModelProvider(
+                api_key=os.getenv("DEEPSEEK_API_KEY", "test-api-key"),
+                provider="deepseek",
+                base_url="https://api.deepseek.com",
+            ),
+            max_tokens=1000,
+            temperature=0.8,
+            top_p=0.7,
+            top_k=8,
+            parallel_tool_calls=False,
+            max_retries=1,
+        )
+        deepseek_client = DeepSeekClient(model_config)
+        self.assertEqual(deepseek_client.base_url, "https://api.deepseek.com")
+        self.assertIsNotNone(deepseek_client.client)
+
+    def test_set_chat_history(self):
+        """Test setting chat history."""
+        model_config = ModelConfig(
+            model=TEST_MODEL,
+            model_provider=ModelProvider(
+                api_key=os.getenv("DEEPSEEK_API_KEY", "test-api-key"),
+                provider="deepseek",
+                base_url="https://api.deepseek.com",
+            ),
+            max_tokens=1000,
+            temperature=0.8,
+            top_p=0.7,
+            top_k=8,
+            parallel_tool_calls=False,
+            max_retries=1,
+        )
+        deepseek_client = DeepSeekClient(model_config)
+        message = LLMMessage("user", "this is a test message")
+        deepseek_client.set_chat_history(messages=[message])
+        self.assertTrue(True)  # runnable
+
+    def test_deepseek_chat(self):
+        """
+        Test the chat method with a simple user message.
+        There is nothing we have to assert for this test case just see if it can run.
+        """
+        model_config = ModelConfig(
+            model=TEST_MODEL,
+            model_provider=ModelProvider(
+                api_key=os.getenv("DEEPSEEK_API_KEY", "test-api-key"),
+                provider="deepseek",
+                base_url="https://api.deepseek.com",
+            ),
+            max_tokens=1000,
+            temperature=0.8,
+            top_p=0.7,
+            top_k=8,
+            parallel_tool_calls=False,
+            max_retries=1,
+        )
+        deepseek_client = DeepSeekClient(model_config)
+        message = LLMMessage("user", "this is a test message")
+        deepseek_client.chat(messages=[message], model_config=model_config)
+        self.assertTrue(True)  # runnable
+
+    def test_supports_tool_calling(self):
+        """
+        Test the supports_tool_calling method.
+        """
+        model_config = ModelConfig(
+            model=TEST_MODEL,
+            model_provider=ModelProvider(
+                api_key=os.getenv("DEEPSEEK_API_KEY", "test-api-key"),
+                provider="deepseek",
+                base_url="https://api.deepseek.com",
+            ),
+            max_tokens=1000,
+            temperature=0.8,
+            top_p=0.7,
+            top_k=8,
+            parallel_tool_calls=False,
+            max_retries=1,
+        )
+        deepseek_client = DeepSeekClient(model_config)
+        self.assertEqual(deepseek_client.supports_tool_calling(model_config), True)
+        model_config.model = "no such model"
+        self.assertEqual(deepseek_client.supports_tool_calling(model_config), True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils/test_qwen_client.py
+++ b/tests/utils/test_qwen_client.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: MIT
+
+"""
+Unit tests for the QwenClient.
+
+WARNING: These tests should not be run in a GitHub Actions workflow
+because they require an API key.
+"""
+
+import os
+import unittest
+
+from trae_agent.utils.config import ModelConfig, ModelProvider
+from trae_agent.utils.llm_clients.qwen_client import QwenClient
+from trae_agent.utils.llm_clients.llm_basics import LLMMessage
+
+TEST_MODEL = "qwen-plus"
+
+
+@unittest.skipIf(
+    os.getenv("SKIP_QWEN_TEST", "").lower() == "true",
+    "Qwen tests skipped due to SKIP_QWEN_TEST environment variable",
+)
+class TestQwenClient(unittest.TestCase):
+    def test_qwen_client_init(self):
+        """Test the initialization of the QwenClient."""
+        model_config = ModelConfig(
+            model=TEST_MODEL,
+            model_provider=ModelProvider(
+                api_key=os.getenv("QWEN_API_KEY", "test-api-key"),
+                provider="qwen",
+                base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            ),
+            max_tokens=1000,
+            temperature=0.8,
+            top_p=0.7,
+            top_k=8,
+            parallel_tool_calls=False,
+            max_retries=1,
+        )
+        qwen_client = QwenClient(model_config)
+        self.assertEqual(qwen_client.base_url, "https://dashscope.aliyuncs.com/compatible-mode/v1")
+        self.assertIsNotNone(qwen_client.client)
+
+    def test_set_chat_history(self):
+        """Test setting chat history."""
+        model_config = ModelConfig(
+            model=TEST_MODEL,
+            model_provider=ModelProvider(
+                api_key=os.getenv("QWEN_API_KEY", "test-api-key"),
+                provider="qwen",
+                base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            ),
+            max_tokens=1000,
+            temperature=0.8,
+            top_p=0.7,
+            top_k=8,
+            parallel_tool_calls=False,
+            max_retries=1,
+        )
+        qwen_client = QwenClient(model_config)
+        message = LLMMessage("user", "this is a test message")
+        qwen_client.set_chat_history(messages=[message])
+        self.assertTrue(True)  # runnable
+
+    def test_qwen_chat(self):
+        """
+        Test the chat method with a simple user message.
+        There is nothing we have to assert for this test case just see if it can run.
+        """
+        model_config = ModelConfig(
+            model=TEST_MODEL,
+            model_provider=ModelProvider(
+                api_key=os.getenv("QWEN_API_KEY", "test-api-key"),
+                provider="qwen",
+                base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            ),
+            max_tokens=1000,
+            temperature=0.8,
+            top_p=0.7,
+            top_k=8,
+            parallel_tool_calls=False,
+            max_retries=1,
+        )
+        qwen_client = QwenClient(model_config)
+        message = LLMMessage("user", "this is a test message")
+        qwen_client.chat(messages=[message], model_config=model_config)
+        self.assertTrue(True)  # runnable
+
+    def test_supports_tool_calling(self):
+        """
+        Test the supports_tool_calling method.
+        """
+        model_config = ModelConfig(
+            model=TEST_MODEL,
+            model_provider=ModelProvider(
+                api_key=os.getenv("QWEN_API_KEY", "test-api-key"),
+                provider="qwen",
+                base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+            ),
+            max_tokens=1000,
+            temperature=0.8,
+            top_p=0.7,
+            top_k=8,
+            parallel_tool_calls=False,
+            max_retries=1,
+        )
+        qwen_client = QwenClient(model_config)
+        self.assertEqual(qwen_client.supports_tool_calling(model_config), True)
+        model_config.model = "no such model"
+        self.assertEqual(qwen_client.supports_tool_calling(model_config), True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trae_agent/utils/llm_clients/deepseek_client.py
+++ b/trae_agent/utils/llm_clients/deepseek_client.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: MIT
+
+"""DeepSeek client wrapper with tool integrations"""
+
+import openai
+
+from trae_agent.utils.config import ModelConfig
+from trae_agent.utils.llm_clients.openai_compatible_base import (
+    OpenAICompatibleClient,
+    ProviderConfig,
+)
+
+
+class DeepSeekProvider(ProviderConfig):
+    """DeepSeek provider configuration."""
+
+    def create_client(
+        self, api_key: str, base_url: str | None, api_version: str | None
+    ) -> openai.OpenAI:
+        """Create OpenAI client with DeepSeek base URL."""
+        return openai.OpenAI(base_url=base_url, api_key=api_key)
+
+    def get_service_name(self) -> str:
+        """Get the service name for retry logging."""
+        return "DeepSeek"
+
+    def get_provider_name(self) -> str:
+        """Get the provider name for trajectory recording."""
+        return "DeepSeek"
+
+    def get_extra_headers(self) -> dict[str, str]:
+        """Get DeepSeek-specific headers (none needed)."""
+        return {}
+
+    def supports_tool_calling(self, model_name: str) -> bool:
+        """Check if the model supports tool calling."""
+        # DeepSeek models generally support tool calling
+        return True
+
+
+class DeepSeekClient(OpenAICompatibleClient):
+    """DeepSeek client wrapper that maintains compatibility while using the new architecture."""
+
+    def __init__(self, model_config: ModelConfig):
+        super().__init__(model_config, DeepSeekProvider())

--- a/trae_agent/utils/llm_clients/llm_client.py
+++ b/trae_agent/utils/llm_clients/llm_client.py
@@ -22,6 +22,8 @@ class LLMProvider(Enum):
     OPENROUTER = "openrouter"
     DOUBAO = "doubao"
     GOOGLE = "google"
+    DEEPSEEK = "deepseek"
+    QWEN = "qwen"
 
 
 class LLMClient:
@@ -60,6 +62,14 @@ class LLMClient:
                 from .google_client import GoogleClient
 
                 self.client = GoogleClient(model_config)
+            case LLMProvider.DEEPSEEK:
+                from .deepseek_client import DeepSeekClient
+
+                self.client = DeepSeekClient(model_config)
+            case LLMProvider.QWEN:
+                from .qwen_client import QwenClient    
+
+                self.client = QwenClient(model_config)
 
     def set_trajectory_recorder(self, recorder: TrajectoryRecorder | None) -> None:
         """Set the trajectory recorder for the underlying client."""

--- a/trae_agent/utils/llm_clients/qwen_client.py
+++ b/trae_agent/utils/llm_clients/qwen_client.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2025 ByteDance Ltd. and/or its affiliates
+# SPDX-License-Identifier: MIT
+
+"""Qwen client wrapper with tool integrations"""
+
+import openai
+
+from trae_agent.utils.config import ModelConfig
+from trae_agent.utils.llm_clients.openai_compatible_base import (
+    OpenAICompatibleClient,
+    ProviderConfig,
+)
+
+
+class QwenProvider(ProviderConfig):
+    """Qwen provider configuration."""
+
+    def create_client(
+        self, api_key: str, base_url: str | None, api_version: str | None
+    ) -> openai.OpenAI:
+        """Create OpenAI client with Qwen base URL."""
+        return openai.OpenAI(base_url=base_url, api_key=api_key)
+
+    def get_service_name(self) -> str:
+        """Get the service name for retry logging."""
+        return "Qwen"
+
+    def get_provider_name(self) -> str:
+        """Get the provider name for trajectory recording."""
+        return "Qwen"
+
+    def get_extra_headers(self) -> dict[str, str]:
+        """Get Qwen-specific headers (none needed)."""
+        return {}
+
+    def supports_tool_calling(self, model_name: str) -> bool:
+        """Check if the model supports tool calling."""
+        # Qwen models generally support tool calling
+        return True
+
+
+class QwenClient(OpenAICompatibleClient):
+    """Qwen client wrapper that maintains compatibility while using the new architecture."""
+
+    def __init__(self, model_config: ModelConfig):
+        super().__init__(model_config, QwenProvider())

--- a/trae_config.yaml.example
+++ b/trae_config.yaml.example
@@ -22,7 +22,18 @@ model_providers:
     anthropic:
         api_key: your_anthropic_api_key
         provider: anthropic
-
+    doubao:
+        api_key: your_doubao_api_key
+        provider: doubao
+        base_url: https://ark.cn-beijing.volces.com/api/v3
+    deepseek:
+        api_key: your_deepseek_api_key
+        provider: deepseek
+        base_url: https://api.deepseek.com
+    qwen:
+        api_key: your_qwen_api_key
+        provider: qwen
+        base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
 models:
     trae_agent_model:
         model_provider: anthropic


### PR DESCRIPTION
## Summary

This PR adds support for two new LLM providers with OpenAI-compatible API endpoints:

- **DeepSeek**: Integration with DeepSeek's API at `https://api.deepseek.com`
  
- **Qwen (通义千问)**: Integration with Alibaba's Qwen models through DashScope's OpenAI-compatible endpoint at `https://dashscope.aliyuncs.com/compatible-mode/v1`
  

Both clients extend the `OpenAICompatibleClient` base class to ensure consistent behavior with existing OpenAI-compatible providers.

## Description

This PR adds support for two new LLM providers: DeepSeek and Qwen (通义千问). Both clients are built using the OpenAICompatibleClient base class to ensure consistent behavior with existing OpenAI-compatible providers.

- DeepSeekClient: Integrates with DeepSeek's API using their OpenAI-compatible endpoint at https://api.deepseek.com/
  
- QwenClient: Integrates with Alibaba's Qwen models through DashScope's OpenAI-compatible mode at https://dashscope.aliyuncs.com/compatible-mode/v1


## More Information

- Created trae_agent/utils/llm_clients/deepseek_client.py with
  DeepSeekClient and DeepSeekProvider classes
  
- Created trae_agent/utils/llm_clients/qwen_client.py with
  QwenClient and QwenProvider classes
  
- Updated trae_agent/utils/llm_clients/llm_client.py to include
  imports for the new clients
  
- Updated trae_config.yaml.example with configuration examples
  for both providers
  
- Added comprehensive unit tests in
  tests/utils/test_deepseek_client.py and
  tests/utils/test_qwen_client.py
  


## Validation

Unit Tests:

- test_deepseek_client_init: Tests client initialization with
  proper configuration
- test_set_chat_history: Tests message history functionality
- test_deepseek_chat: Tests basic chat functionality
- test_supports_tool_calling: Tests tool calling support
  detection
- Similar tests for QwenClient
- Tests can be skipped via SKIP_DEEPSEEK_TEST=true and
  SKIP_QWEN_TEST=true environment variables

Manual Testing:

```bash
# For DeepSeek
  export DEEPSEEK_API_KEY="your-api-key"
  python -m pytest tests/utils/test_deepseek_client.py -v

  # For Qwen  
  export QWEN_API_KEY="your-api-key"
  python -m pytest tests/utils/test_qwen_client.py -v
```

## Configuration Example

The `trae_config.yaml.example` has been updated with configuration examples for both providers:

```yaml
agents:
    trae_agent:
        enable_lakeview: true
        model: trae_agent_model
        max_steps: 200
        tools:
            - bash
            - str_replace_based_edit_tool
            - sequentialthinking
            - task_done
allow_mcp_servers:
    - playwright
mcp_servers:
    playwright:
        command: npx
        args:
            - "@playwright/mcp@0.0.27"
lakeview:
    model: lakeview_model

model_providers:
    anthropic:
        api_key: your_anthropic_api_key
        provider: anthropic
    doubao:
        api_key: your_doubao_api_key
        provider: doubao
        base_url: https://ark.cn-beijing.volces.com/api/v3
    deepseek:
        api_key: your_deepseek_api_key
        provider: deepseek
        base_url: https://api.deepseek.com
    qwen:
        api_key: your_qwen_api_key
        provider: qwen
        base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
models:
    trae_agent_model:
        model_provider: deepseek
        model: deepseek-chat
        max_tokens: 4096
        temperature: 0.5
        top_p: 1
        top_k: 0
        max_retries: 10
        parallel_tool_calls: true
    lakeview_model:
        model_provider: qwen
        model: qwen-turbo
        max_tokens: 4096
        temperature: 0.5
        top_p: 1
        top_k: 0
        max_retries: 10
        parallel_tool_calls: true
```

## Linked Issues

N/A