### PR TITLE
fix(openai): persist tool outputs in message history

### DIFF
--- a/trae_agent/utils/llm_clients/openai_client.py
+++ b/trae_agent/utils/llm_clients/openai_client.py
@@ -69,6 +69,11 @@ class OpenAIClient(BaseLLMClient):
         """Send chat messages to OpenAI with optional tool support."""
         openai_messages: ResponseInputParam = self.parse_messages(messages)
 
+        if reuse_history:
+            self.message_history = self.message_history + openai_messages
+        else:
+            self.message_history = openai_messages
+
         tool_schemas = None
         if tools:
             tool_schemas = [
@@ -82,10 +87,7 @@ class OpenAIClient(BaseLLMClient):
                 for tool in tools
             ]
 
-        api_call_input: ResponseInputParam = []
-        if reuse_history:
-            api_call_input.extend(self.message_history)
-        api_call_input.extend(openai_messages)
+        api_call_input: ResponseInputParam = self.message_history
 
         # Apply retry decorator to the API call
         retry_decorator = retry_with(


### PR DESCRIPTION
## Description
Fixes an OpenAI Responses API error by persisting tool call outputs into message_history before subsequent requests. This prevents “No tool output found for function call …” failures when tool calls are present across turns.

## More Information
Updated OpenAIClient.chat() to merge newly parsed messages (including tool outputs) into message_history when reuse_history=True.
API input now uses the updated message_history, aligning behavior with other clients and ensuring tool outputs are sent back to OpenAI.
Potential impact:

OpenAI tool-call flows now continue across steps without 400 errors from missing tool outputs.

## Validation
Run `trae-cli run "Create a hello world Python script"`.

Before fix:
<img width="902" height="350" alt="treesttitslle_clietsopenal_ellent py  Line 48, 1e _create speat_ respond" src="https://github.com/user-attachments/assets/397e19bd-acfa-45a6-9f76-31fcb220d23f" />

After fix:
No “No tool output found for function call" failures for OpenAI models.
<img width="572" height="175" alt="image" src="https://github.com/user-attachments/assets/78dbd613-c369-4413-8b9d-c3f8f1401b19" />

## Linked Issues
- Resolves #361 
- Resolves #358 
- Resolves #353 

