### PR TITLE
fix: install docker and pexpect module on docker environment while so…

### DIFF
--- a/evaluation/run_evaluation.py
+++ b/evaluation/run_evaluation.py
@@ -176,6 +176,7 @@ class BenchmarkEvaluation:
             "rm -rf /trae-workspace/trae-agent && mkdir /trae-workspace/trae-agent",
             "cp -r -t /trae-workspace/trae-agent/ /trae-src/trae_agent /trae-src/.python-version /trae-src/pyproject.toml /trae-src/uv.lock /trae-src/README.md",
             "cd /trae-workspace/trae-agent && source $HOME/.local/bin/env && uv sync",
+            "cd /trae-workspace/trae-agent && source $HOME/.local/bin/env && uv pip install docker pexpect",
         ]
 
         for command in tqdm(


### PR DESCRIPTION
…lving swebench problems

## Description

This PR fixes missing Python dependency installation in the SWE-bench evaluation pipeline for Trae Agent. When running evaluations, Trae Agent fails due to missing docker and pexpect modules inside the Docker container environment where it executes.

The fix adds uv pip install docker pexpect to the build commands in evaluation/run_evaluation.py, ensuring these critical dependencies are available when Trae Agent runs inside evaluation containers.
