### PR TITLE
fix: improve type safety in legacy config migration

### DIFF
--- a/trae_agent/utils/config.py
+++ b/trae_agent/utils/config.py
@@ -343,23 +343,19 @@ class Config:
             provider=legacy_config.default_provider,
         )
 
+        provider_config = legacy_config.model_providers[legacy_config.default_provider]
+
         model_config = ModelConfig(
-            model=legacy_config.model_providers[legacy_config.default_provider].model,
+            model=provider_config.model,
             model_provider=model_provider,
-            max_tokens=legacy_config.model_providers[legacy_config.default_provider].max_tokens,
-            temperature=legacy_config.model_providers[legacy_config.default_provider].temperature,
-            top_p=legacy_config.model_providers[legacy_config.default_provider].top_p,
-            top_k=legacy_config.model_providers[legacy_config.default_provider].top_k,
-            parallel_tool_calls=legacy_config.model_providers[
-                legacy_config.default_provider
-            ].parallel_tool_calls,
-            max_retries=legacy_config.model_providers[legacy_config.default_provider].max_retries,
-            candidate_count=legacy_config.model_providers[
-                legacy_config.default_provider
-            ].candidate_count,
-            stop_sequences=legacy_config.model_providers[
-                legacy_config.default_provider
-            ].stop_sequences,
+            max_tokens=provider_config.max_tokens,
+            temperature=provider_config.temperature,
+            top_p=provider_config.top_p,
+            top_k=provider_config.top_k if provider_config.top_k is not None else 0,
+            parallel_tool_calls=provider_config.parallel_tool_calls,
+            max_retries=provider_config.max_retries,
+            candidate_count=provider_config.candidate_count,
+            stop_sequences=provider_config.stop_sequences,
         )
         mcp_servers_config = {
             k: MCPServerConfig(**vars(v)) for k, v in legacy_config.mcp_servers.items()


### PR DESCRIPTION
## Summary
This PR improves type safety in the legacy configuration migration code by adding defensive checks for `top_k` parameter.

## Changes
- **Add None check for top_k**: Prevents potential type errors when the legacy config has missing or null top_k values
- **Code refactoring**: Extract `provider_config` variable to eliminate code duplication
- **Improved readability**: Reduced repeated attribute access from 10+ times to a single variable

## Problem
When migrating from legacy JSON configs, the `top_k` field could theoretically be None, which would cause type mismatches since `ModelConfig.top_k` expects an `int`.

## Solution
Added defensive check: `top_k=provider_config.top_k if provider_config.top_k is not None else 0`

This ensures we always pass a valid int value to ModelConfig, maintaining backward compatibility while improving type safety.

## Testing
- No functional changes for existing valid configs
- Defensive measure for edge cases
- Reduces code duplication (11 insertions, 15 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)