### PR TITLE
Fix grammar in evaluation README

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -27,7 +27,7 @@ Before running the evaluation, ensure you have:
 
 ## Setup Instructions
 
-Make sure installing extra dependencies for evaluation and running scripts in the `evaluation` directory.
+Make sure to install extra dependencies for evaluation and run scripts in the `evaluation` directory.
 
 ```bash
 uv sync --extra evaluation


### PR DESCRIPTION
Fixes grammatical error in evaluation/README.md where 'Make sure installing' has been corrected to 'Make sure to install'.