### PR TITLE
fix: [#376] Prevent command injection in TextEditorTool._view()

### DIFF
--- a/trae_agent/tools/edit_tool.py
+++ b/trae_agent/tools/edit_tool.py
@@ -159,7 +159,32 @@ Notes for using the `str_replace` command:
                     "The `view_range` parameter is not allowed when `path` points to a directory."
                 )
 
-            return_code, stdout, stderr = await run(rf"find {path} -maxdepth 2 -not -path '*/\.*'")
+            # Use subprocess with list arguments to prevent shell injection
+            # from directory names containing shell metacharacters.
+            import asyncio as _asyncio
+
+            try:
+                proc = await _asyncio.create_subprocess_exec(
+                    "find",
+                    str(path),
+                    "-maxdepth",
+                    "2",
+                    "-not",
+                    "-path",
+                    "*/.*",
+                    stdout=_asyncio.subprocess.PIPE,
+                    stderr=_asyncio.subprocess.PIPE,
+                )
+                stdout_bytes, stderr_bytes = await proc.communicate()
+                return_code = proc.returncode or 0
+                stdout = stdout_bytes.decode()
+                stderr = stderr_bytes.decode()
+            except Exception as e:
+                return ToolExecResult(
+                    error=f"Error listing directory: {e}",
+                    error_code=-1,
+                )
+
             if not stderr:
                 stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
             return ToolExecResult(error_code=return_code, output=stdout, error=stderr)


### PR DESCRIPTION
Fixes #376

## Problem
The `_view()` method in `TextEditorTool` interpolated the user-supplied path directly into a shell command string passed to `create_subprocess_shell`. A directory name containing shell metacharacters (e.g. `; rm -rf /`, `$(malicious_command)`) could execute arbitrary commands.

## Solution
Replaced the shell-based `find` invocation with `asyncio.create_subprocess_exec` using a list of arguments. This bypasses the shell entirely, so metacharacters in path names are treated as literal characters by `find(1)`.

## Changes
- In `_view()`: replaced `await run(rf"find {path} ...")` with `await asyncio.create_subprocess_exec("find", str(path), ...)`
- The path is now passed as a separate argument, preventing shell interpretation