### PR TITLE
fix: [#86] Improve trae-cli installation docs and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,10 +253,26 @@ echo $OPENAI_API_KEY
 trae-cli show-config
 ```
 
-**Command Not Found:**
+**`trae-cli: command not found`:**
+
+This happens when the virtual environment's `bin/` directory is not on your `PATH`. Fix it with one of these approaches:
+
 ```bash
+# Option 1: Activate the virtual environment (recommended)
+source .venv/bin/activate
+trae-cli run "your task"
+
+# Option 2: Use `uv run` (no activation needed)
 uv run trae-cli run "your task"
+
+# Option 3: Call the binary directly
+.venv/bin/trae-cli run "your task"
 ```
+
+> **Tip:** If the command disappears after opening a new terminal, make sure you activate the venv first (`source .venv/bin/activate`). You can add this to your shell profile for convenience:
+> ```bash
+> echo 'source /path/to/trae-agent/.venv/bin/activate' >> ~/.bashrc
+> ```
 
 **Permission Errors:**
 ```bash


### PR DESCRIPTION
Fixes #86

## Problem
After installing trae-agent with `uv sync`, running `trae-cli` directly produces "command not found" because the virtual environment bin directory is not on PATH by default.

## Solution
Expanded the troubleshooting section in README.md with three clear approaches to running trae-cli:
1. Activate the virtual environment (`source .venv/bin/activate`)
2. Use `uv run` (no activation needed)
3. Call the binary directly (`.venv/bin/trae-cli`)

Also added a tip about persisting venv activation in shell profile for convenience.