### PR TITLE
fix: [#91] Fix build success detection for negative exit codes

### DIFF
--- a/trae_agent/agent/docker_manager.py
+++ b/trae_agent/agent/docker_manager.py
@@ -216,7 +216,7 @@ class DockerManager:
         self.shell.sendline(full_command)
         self.shell.sendline(marker_command)
         try:
-            self.shell.expect(marker + r"(\d+)", timeout=timeout)
+            self.shell.expect(marker + r"(-?\d+)", timeout=timeout)
         except pexpect.exceptions.TIMEOUT:
             return (
                 -1,


### PR DESCRIPTION
Fixes #91

## Problem
In `docker_manager.py`, the `_execute_interactive` method uses regex `(\d+)` to capture the exit code from shell commands. This fails to match negative exit codes like `-1` (returned on timeout or error), causing the success detection to be incorrect.

## Solution
Changed the regex from `(\d+)` to `(-?\d+)` to allow an optional leading minus sign. This enables proper detection of:
- Success: exit code `0`
- Failure: any non-zero exit code (positive or negative like `-1`)

## Changes
- In `docker_manager.py` line ~183: Changed regex pattern from `r"(\d+)"` to `r"(-?\d+)"`