### PR TITLE
fix: [#102] Fix configuration priority order to match documentation

### DIFF
--- a/trae_agent/utils/config.py
+++ b/trae_agent/utils/config.py
@@ -397,14 +397,14 @@ def resolve_config_value(
     config_value: int | str | float | None,
     env_var: str | None = None,
 ) -> int | str | float | None:
-    """Resolve configuration value with priority: CLI > ENV > Config > Default."""
+    """Resolve configuration value with priority: CLI > Config > ENV > Default."""
     if cli_value is not None:
         return cli_value
 
-    if env_var and os.getenv(env_var):
-        return os.getenv(env_var)
-
     if config_value is not None:
         return config_value
+
+    if env_var and os.getenv(env_var):
+        return os.getenv(env_var)
 
     return None


### PR DESCRIPTION
Fixes #102

## Problem
The `resolve_config_value` function in `config.py` had conflicting priority definitions:
- **Code**: CLI > ENV > Config > Default
- **Documentation (README)**: CLI > Config > ENV > Default

This caused confusion and unexpected behavior where environment variables would override values in the config file, contrary to what users would expect from reading the docs.

## Solution
Reordered the priority checks in `resolve_config_value` to match the documented priority:

```python
# Before (wrong):
if cli_value is not None: return cli_value
if env_var and os.getenv(env_var): return os.getenv(env_var)  # ENV checked before Config
if config_value is not None: return config_value

# After (correct):
if cli_value is not None: return cli_value
if config_value is not None: return config_value  # Config checked before ENV
if env_var and os.getenv(env_var): return os.getenv(env_var)
```

The docstring was also updated to reflect the correct priority.