### PR TITLE
[Security] Address high-severity command injection risk in edit_tool directory view

### DIFF
--- a/evaluation/patch_selection/trae_selector/tools/tools/edit.py
+++ b/evaluation/patch_selection/trae_selector/tools/tools/edit.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Literal, get_args
 
 from base import CLIResult, ToolError, ToolResult
-from run import maybe_truncate, run
+from run import maybe_truncate
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 Command = Literal[
@@ -94,6 +94,32 @@ class EditTool:
                 f"The path {path} is a directory and only the `view` command can be used on directories"
             )
 
+    def _list_directory(self, path: Path, max_depth: int = 2) -> str:
+        lines = [str(path)]
+        self._walk_directory(path, lines, current_depth=0, max_depth=max_depth)
+        return "\n".join(lines)
+
+    def _walk_directory(
+        self, directory: Path, lines: list[str], current_depth: int, max_depth: int
+    ) -> None:
+        if current_depth >= max_depth:
+            return
+
+        try:
+            entries = sorted(
+                (entry for entry in directory.iterdir() if not entry.name.startswith(".")),
+                key=lambda entry: entry.name,
+            )
+        except OSError as exc:
+            raise ToolError(f"Failed to list directory {directory}: {exc}") from exc
+
+        for entry in entries:
+            lines.append(str(entry))
+            if entry.is_dir():
+                self._walk_directory(
+                    entry, lines, current_depth=current_depth + 1, max_depth=max_depth
+                )
+
     async def view(self, path: Path, view_range: list[int] | None = None):
         if path.is_dir():
             if view_range:
@@ -101,10 +127,9 @@ class EditTool:
                     "The `view_range` parameter is not allowed when `path` points to a directory."
                 )
 
-            _, stdout, stderr = await run(rf"find {path} -maxdepth 2 -not -path '*/\.*'")
-            if not stderr:
-                stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
-            return CLIResult(output=stdout, error=stderr)
+            stdout = self._list_directory(path)
+            stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
+            return CLIResult(output=stdout, error="")
 
         file_content = self.read_file(path)
         init_line = 1

--- a/tests/tools/test_edit_tool.py
+++ b/tests/tools/test_edit_tool.py
@@ -3,7 +3,8 @@
 
 import unittest
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from trae_agent.tools.base import ToolCallArguments
 from trae_agent.tools.edit_tool import TextEditorTool
@@ -101,13 +102,45 @@ class TestTextEditorTool(unittest.IsolatedAsyncioTestCase):
         self.assertIn("edited", result.output)
 
     async def test_view_directory(self):
-        self.mock_file_system(exists=True, is_dir=True)
-        with patch("trae_agent.tools.edit_tool.run", new_callable=AsyncMock) as mock_run:
-            mock_run.return_value = (0, "file1\nfile2", "")
+        with TemporaryDirectory() as temp_dir:
+            test_dir = Path(temp_dir)
+            child = test_dir / "file1.txt"
+            nested_dir = test_dir / "nested"
+            hidden_child = test_dir / ".hidden.txt"
+            child.write_text("hello")
+            nested_dir.mkdir()
+            (nested_dir / "file2.txt").write_text("world")
+            hidden_child.write_text("ignore me")
             result = await self.tool.execute(
-                ToolCallArguments({"command": "view", "path": str(self.test_dir)})
+                ToolCallArguments({"command": "view", "path": str(test_dir)})
             )
         self.assertIn("files and directories", result.output)
+        self.assertIn(str(test_dir), result.output)
+        self.assertIn(str(child), result.output)
+        self.assertIn(str(nested_dir / "file2.txt"), result.output)
+        self.assertNotIn(str(hidden_child), result.output)
+
+    async def test_view_directory_with_shell_metacharacters_does_not_execute(self):
+        marker = Path.cwd() / "edit_tool_shell_injection_marker"
+        if marker.exists():
+            marker.unlink()
+
+        try:
+            with TemporaryDirectory(prefix="edit;touch edit_tool_shell_injection_marker;#") as temp_dir:
+                test_dir = Path(temp_dir)
+                child = test_dir / "file1.txt"
+                child.write_text("hello")
+                result = await self.tool.execute(
+                    ToolCallArguments({"command": "view", "path": str(test_dir)})
+                )
+        finally:
+            if marker.exists():
+                marker.unlink()
+
+        self.assertEqual(result.error_code, 0)
+        self.assertFalse(marker.exists())
+        self.assertIn(str(test_dir), result.output)
+        self.assertIn(str(child), result.output)
 
     async def test_view_file(self):
         self.mock_file_system(exists=True, is_dir=False, content="line1\nline2\nline3")

--- a/trae_agent/tools/edit_tool.py
+++ b/trae_agent/tools/edit_tool.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import override
 
 from trae_agent.tools.base import Tool, ToolCallArguments, ToolError, ToolExecResult, ToolParameter
-from trae_agent.tools.run import maybe_truncate, run
+from trae_agent.tools.run import maybe_truncate
 
 EditToolSubCommands = [
     "view",
@@ -151,6 +151,34 @@ Notes for using the `str_replace` command:
                 f"The path {path} is a directory and only the `view` command can be used on directories"
             )
 
+    def _list_directory(self, path: Path, max_depth: int = 2) -> str:
+        """Safely list non-hidden files and directories up to the requested depth."""
+        lines = [str(path)]
+        self._walk_directory(path, lines, current_depth=0, max_depth=max_depth)
+        return "\n".join(lines)
+
+    def _walk_directory(
+        self, directory: Path, lines: list[str], current_depth: int, max_depth: int
+    ) -> None:
+        """Recursively enumerate directory contents without invoking a shell."""
+        if current_depth >= max_depth:
+            return
+
+        try:
+            entries = sorted(
+                (entry for entry in directory.iterdir() if not entry.name.startswith(".")),
+                key=lambda entry: entry.name,
+            )
+        except OSError as exc:
+            raise ToolError(f"Failed to list directory {directory}: {exc}") from exc
+
+        for entry in entries:
+            lines.append(str(entry))
+            if entry.is_dir():
+                self._walk_directory(
+                    entry, lines, current_depth=current_depth + 1, max_depth=max_depth
+                )
+
     async def _view(self, path: Path, view_range: list[int] | None = None) -> ToolExecResult:
         """Implement the view command"""
         if path.is_dir():
@@ -159,10 +187,9 @@ Notes for using the `str_replace` command:
                     "The `view_range` parameter is not allowed when `path` points to a directory."
                 )
 
-            return_code, stdout, stderr = await run(rf"find {path} -maxdepth 2 -not -path '*/\.*'")
-            if not stderr:
-                stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
-            return ToolExecResult(error_code=return_code, output=stdout, error=stderr)
+            stdout = self._list_directory(path)
+            stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
+            return ToolExecResult(error_code=0, output=stdout, error="")
 
         file_content = self.read_file(path)
         init_line = 1

--- a/trae_agent/tools/edit_tool_cli.py
+++ b/trae_agent/tools/edit_tool_cli.py
@@ -50,24 +50,6 @@ EditToolSubCommands = ["view", "create", "str_replace", "insert"]
 SNIPPET_LINES = 5
 
 
-async def run(command: str, timeout: int = 300) -> tuple[int, str, str]:
-    """Run a shell command asynchronously."""
-    proc = await asyncio.create_subprocess_shell(
-        command,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    try:
-        stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
-        stdout = stdout_bytes.decode("utf-8", errors="ignore")
-        stderr = stderr_bytes.decode("utf-8", errors="ignore")
-        return proc.returncode if proc.returncode is not None else -1, stdout, stderr
-    except asyncio.TimeoutError:
-        proc.kill()
-        await proc.wait()
-        return -1, "", f"Command timed out after {timeout} seconds."
-
-
 class TextEditorTool(Tool):
     """Tool to replace a string in a file."""
 
@@ -195,6 +177,34 @@ Notes for using the `str_replace` command:
                 f"The path {path} is a directory and only the `view` command can be used on directories"
             )
 
+    def _list_directory(self, path: Path, max_depth: int = 2) -> str:
+        """Safely list non-hidden files and directories up to the requested depth."""
+        lines = [str(path)]
+        self._walk_directory(path, lines, current_depth=0, max_depth=max_depth)
+        return "\n".join(lines)
+
+    def _walk_directory(
+        self, directory: Path, lines: list[str], current_depth: int, max_depth: int
+    ) -> None:
+        """Recursively enumerate directory contents without invoking a shell."""
+        if current_depth >= max_depth:
+            return
+
+        try:
+            entries = sorted(
+                (entry for entry in directory.iterdir() if not entry.name.startswith(".")),
+                key=lambda entry: entry.name,
+            )
+        except OSError as exc:
+            raise ToolError(f"Failed to list directory {directory}: {exc}") from exc
+
+        for entry in entries:
+            lines.append(str(entry))
+            if entry.is_dir():
+                self._walk_directory(
+                    entry, lines, current_depth=current_depth + 1, max_depth=max_depth
+                )
+
     async def _view(self, path: Path, view_range: list[int] | None = None) -> ToolExecResult:
         """Implement the view command"""
         if path.is_dir():
@@ -203,10 +213,9 @@ Notes for using the `str_replace` command:
                     "The `view_range` parameter is not allowed when `path` points to a directory."
                 )
 
-            return_code, stdout, stderr = await run(rf"find {path} -maxdepth 2 -not -path '*/\.*'")
-            if not stderr:
-                stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
-            return ToolExecResult(error_code=return_code, output=stdout, error=stderr)
+            stdout = self._list_directory(path)
+            stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
+            return ToolExecResult(error_code=0, output=stdout, error="")
 
         file_content = self.read_file(path)
         init_line = 1


### PR DESCRIPTION
## Security Context
This PR addresses a high-severity command-injection risk in `str_replace_based_edit_tool` directory views.

## CVSS
CVSS v3.1: `7.8` (`AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H`)
This is scored as high rather than critical because exploitation requires user interaction and control over a local path input, not a remotely reachable unauthenticated attack surface.

## Summary
- replace shell-based directory listing in `str_replace_based_edit_tool` with a pure-Python walker
- apply the same fix to the packaged CLI copy and the evaluation harness copy
- add regression tests covering hidden-file filtering and paths containing shell metacharacters

## Root cause
When `view` was used on a directory, the tool constructed a shell command using the supplied path and executed it via a shell helper. Because the path was not treated as inert data, crafted directory names containing shell metacharacters could trigger unintended host-side command execution.

## Why this is affected
The vulnerable flow is straightforward:

1. `str_replace_based_edit_tool` accepts a caller-supplied `path` argument for `view`.
2. `validate_path()` only checks that the path is absolute, exists, and is a directory when `view` is used.
3. `_view()` then interpolated that path directly into a command string of the form `find {path} -maxdepth 2 -not -path '*/\\.*'`.
4. That command string was executed through the shell helper, which uses `asyncio.create_subprocess_shell(...)`.
5. Because the path was embedded into a shell command without quoting or escaping, any shell metacharacters present in the directory name were interpreted by the shell instead of being treated as literal path characters.

This means the bug is not in path validation itself, but in the trust boundary after validation: a valid existing directory path was later reinterpreted as shell syntax.

This is especially risky because:
- directory names on Unix-like systems can legally contain shell metacharacters such as `;`, `&`, `|`, backticks, and `$()`
- the affected operation is a benign-looking `view` request rather than an explicitly dangerous execution tool
- the same pattern existed in the main tool implementation, the packaged CLI copy, and the evaluation harness copy

## Impact
Under the right conditions, this could allow commands to run as the same user executing `trae-cli`. In practice, that means access to files, credentials, and repository contents available to that user, along with the ability to modify or damage the local workspace.

## Fix
Use a pure-Python directory walker that:
- never invokes a shell
- preserves the existing "list up to 2 levels deep" behavior
- continues excluding hidden entries

This removes the injection surface rather than trying to escape around it.

## Validation
- `uv run --extra test --extra evaluation pytest tests/tools/test_edit_tool.py`
- `uv run --extra test --extra evaluation pytest tests/tools/test_json_edit_tool.py`
- `uv run ruff check trae_agent/tools/edit_tool.py trae_agent/tools/edit_tool_cli.py evaluation/patch_selection/trae_selector/tools/tools/edit.py tests/tools/test_edit_tool.py`
