### PR TITLE
fix: correct docker workspace path in task prompt

### DIFF
--- a/trae_agent/agent/trae_agent.py
+++ b/trae_agent/agent/trae_agent.py
@@ -130,7 +130,7 @@ class TraeAgent(BaseAgent):
 
         self.project_path = extra_args.get("project_path", "")
         if self.docker_config:
-            user_message += r"[Project root path]:\workspace\n\n"
+            user_message += "[Project root path]:/workspace\n\n"
         else:
             user_message += f"[Project root path]:\n{self.project_path}\n\n"
 


### PR DESCRIPTION
## Summary
- Fix raw string literal bug in `trae_agent.py:133` where `r"[Project root path]:\workspace\n\n"` produced incorrect output

## Problem
The raw string prefix `r` on line 133 caused two bugs:
1. `\n` was NOT interpreted as newlines — producing literal `\n` characters in the prompt text sent to the LLM
2. The workspace path used `\workspace` (backslash) instead of `/workspace` (forward slash), which is incorrect for Docker containers running Linux

## Fix
Changed `r"[Project root path]:\workspace\n\n"` to `"[Project root path]:/workspace\n\n"`

## Test plan
- [ ] Run agent with docker config and verify the prompt contains proper newlines and `/workspace` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)