### PR TITLE
fix: escape path in find command to prevent shell injection

### DIFF
--- a/trae_agent/tools/edit_tool.py
+++ b/trae_agent/tools/edit_tool.py
@@ -9,6 +9,7 @@
 #
 # This modified file is released under the same license.
 
+import shlex
 from pathlib import Path
 from typing import override
 
@@ -159,7 +160,9 @@ Notes for using the `str_replace` command:
                     "The `view_range` parameter is not allowed when `path` points to a directory."
                 )
 
-            return_code, stdout, stderr = await run(rf"find {path} -maxdepth 2 -not -path '*/\.*'")
+            return_code, stdout, stderr = await run(
+                rf"find {shlex.quote(str(path))} -maxdepth 2 -not -path '*/\.*'"
+            )
             if not stderr:
                 stdout = f"Here's the files and directories up to 2 levels deep in {path}, excluding hidden items:\n{stdout}\n"
             return ToolExecResult(error_code=return_code, output=stdout, error=stderr)


### PR DESCRIPTION
## Summary
- Fix shell injection vulnerability in `edit_tool.py:162` where the `path` parameter is passed unsanitized to a `find` shell command

## Problem
In `TextEditorTool._view()`, when viewing a directory, the path is interpolated directly into a shell command:
```python
return_code, stdout, stderr = await run(rf"find {path} -maxdepth 2 -not -path '*/\.*'")
```
The `run()` function uses `asyncio.create_subprocess_shell()`, so a path containing shell metacharacters could execute arbitrary commands.

## Fix
Use `shlex.quote()` to properly escape the path before passing it to the shell command.

## Test plan
- [ ] Verify normal directory viewing still works
- [ ] Test with paths containing spaces, semicolons, or other shell metacharacters

🤖 Generated with [Claude Code](https://claude.com/claude-code)