### PR TITLE
fix: use bare raise instead of raise e to preserve traceback

### DIFF
--- a/trae_agent/utils/mcp_client.py
+++ b/trae_agent/utils/mcp_client.py
@@ -68,8 +68,8 @@ class MCPClient:
             for tool in mcp_tools.tools:
                 mcp_tool = MCPTool(self, tool, model_provider)
                 mcp_tools_container.append(mcp_tool)
-        except Exception as e:
-            raise e
+        except Exception:
+            raise
 
     async def connect_to_server(self, mcp_server_name, transport):
         """Connect to an MCP server


### PR DESCRIPTION
## Summary
- Fix improper exception re-raising in `mcp_client.py:71` that loses the original traceback

## Problem
In `MCPClient.connect_and_discover()`, the exception handler:
```python
except Exception as e:
    raise e
```
This discards the original traceback, making it harder to debug issues. In Python, `raise e` creates a new exception from the current location, while bare `raise` preserves the original traceback and exception chain.

## Fix
Changed to bare `raise` to preserve the full exception context for debugging.

## Test plan
- [ ] Verify MCP connection errors still propagate correctly
- [ ] Verify traceback now shows the original error location

🤖 Generated with [Claude Code](https://claude.com/claude-code)