### PR TITLE
fix: replace unsafe os.system calls with Python stdlib in build script

### DIFF
--- a/trae_agent/cli.py
+++ b/trae_agent/cli.py
@@ -87,7 +87,9 @@ def check_docker(timeout=3):
 
 
 def build_with_pyinstaller():
-    os.system("rm -rf trae_agent/dist")
+    dist_dir = os.path.join("trae_agent", "dist")
+    if os.path.exists(dist_dir):
+        shutil.rmtree(dist_dir)
     print("--- Building edit_tool ---")
     subprocess.run(
         [
@@ -109,11 +111,14 @@ def build_with_pyinstaller():
         ],
         check=True,
     )
-    os.system("mkdir trae_agent/dist")
-    os.system("cp dist/edit_tool/edit_tool trae_agent/dist")
-    os.system("cp -r dist/json_edit_tool/_internal trae_agent/dist")
-    os.system("cp dist/json_edit_tool/json_edit_tool trae_agent/dist")
-    os.system("rm -rf dist")
+    os.makedirs(dist_dir, exist_ok=True)
+    shutil.copy(os.path.join("dist", "edit_tool", "edit_tool"), dist_dir)
+    shutil.copytree(
+        os.path.join("dist", "json_edit_tool", "_internal"),
+        os.path.join(dist_dir, "_internal"),
+    )
+    shutil.copy(os.path.join("dist", "json_edit_tool", "json_edit_tool"), dist_dir)
+    shutil.rmtree("dist")
 
 
 @click.group()


### PR DESCRIPTION
## Summary
- Replace `os.system("rm -rf ...")` and `os.system("cp ...")` calls in `build_with_pyinstaller()` with safer Python stdlib equivalents (`shutil`, `os`)

## Problem
The `build_with_pyinstaller()` function uses `os.system()` to run shell commands like `rm -rf`, `cp`, and `mkdir`. This is problematic because:
1. **Security**: `os.system()` spawns a shell, introducing potential injection vectors
2. **Cross-platform**: `rm` and `cp` are Unix-only commands; they don't exist on Windows
3. **Error handling**: `os.system()` only returns an exit code — no proper exceptions on failure

## Fix
Replaced all `os.system()` calls with:
- `shutil.rmtree()` instead of `rm -rf`
- `shutil.copy()` instead of `cp`
- `shutil.copytree()` instead of `cp -r`
- `os.makedirs()` instead of `mkdir`

## Test plan
- [ ] Run `build_with_pyinstaller()` and verify the build output is identical
- [ ] Verify it works on both Unix and Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)