### PR TITLE
fix: remove unreachable absolute path check in CLI run command

### DIFF
--- a/trae_agent/cli.py
+++ b/trae_agent/cli.py
@@ -342,13 +342,6 @@ def run(
         working_dir = os.getcwd()
         console.print(f"[blue]Using current directory as working directory: {working_dir}[/blue]")
 
-    # Ensure working directory is an absolute path
-    if not Path(working_dir).is_absolute():
-        console.print(
-            f"[red]Working directory must be an absolute path: {working_dir}, it should start with `/`[/red]"
-        )
-        sys.exit(1)
-
     agent = Agent(
         agent_type,
         config,


### PR DESCRIPTION
## Summary
- Remove dead code in `cli.py:345-350` that checks if `working_dir` is an absolute path but can never be reached

## Problem
In the `run()` command, the block:
```python
if not Path(working_dir).is_absolute():
    console.print(
        f"[red]Working directory must be an absolute path: {working_dir}, it should start with `/`[/red]"
    )
    sys.exit(1)
```
is unreachable because both code branches above guarantee an absolute path:
- **When `working_dir` is provided**: `os.path.abspath(working_dir)` on line 336 always returns an absolute path
- **When `working_dir` is not provided**: `os.getcwd()` on line 342 always returns an absolute path

This error message could never actually be displayed to the user.

## Fix
Removed the unreachable block.

## Test plan
- [ ] Verify `trae run "task" --working-dir ./relative` still works (abspath handles it)
- [ ] Verify `trae run "task"` without working-dir still works (uses cwd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)